### PR TITLE
Add a generic state-driven emulator control CLI and improve Windows build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Build artifacts
 build/
+build-codex/
+build-codex-*/
 *.o
 *.d
 *.a
@@ -36,3 +38,5 @@ crosspoint_emulator
 # Temporary files
 *.tmp
 *.log
+simctl-*.txt
+tools/tmp-*.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,12 +1,26 @@
 cmake_minimum_required(VERSION 3.16)
 project(crosspoint-emulator CXX C)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
-# Crosspoint repo path (sibling by default)
+# Crosspoint repo path (try common sibling names by default)
+if(NOT DEFINED CROSSPOINT_ROOT)
+  set(_crosspoint_root_candidates
+    "${CMAKE_CURRENT_SOURCE_DIR}/../Crosspoint"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../crosspoint-reader"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../crosspoint-reader/crosspoint-reader"
+  )
+  foreach(_crosspoint_candidate IN LISTS _crosspoint_root_candidates)
+    if(EXISTS "${_crosspoint_candidate}/src/main.cpp")
+      set(CROSSPOINT_ROOT "${_crosspoint_candidate}")
+      break()
+    endif()
+  endforeach()
+endif()
 if(NOT DEFINED CROSSPOINT_ROOT)
   set(CROSSPOINT_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../Crosspoint")
 endif()
+file(TO_CMAKE_PATH "${CROSSPOINT_ROOT}" CROSSPOINT_ROOT)
 
 # Optional: point to a local SDL2 install (e.g. from Downloads or built from source)
 # Usage: cmake -DSDL2_ROOT=/path/to/SDL2-2.30.2 ..
@@ -35,8 +49,16 @@ endif()
 
 # Pre-build: generate HTML headers if Crosspoint src exists
 if(EXISTS "${CROSSPOINT_ROOT}/scripts/build_html.py")
+  if(WIN32)
+    find_program(CROSSPOINT_PYTHON NAMES python py)
+  else()
+    find_program(CROSSPOINT_PYTHON NAMES python3 python)
+  endif()
+endif()
+
+if(EXISTS "${CROSSPOINT_ROOT}/scripts/build_html.py" AND CROSSPOINT_PYTHON)
   execute_process(
-    COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=" python3 "${CROSSPOINT_ROOT}/scripts/build_html.py"
+    COMMAND "${CMAKE_COMMAND}" -E env "PYTHONPATH=" "${CROSSPOINT_PYTHON}" "${CROSSPOINT_ROOT}/scripts/build_html.py"
     WORKING_DIRECTORY "${CROSSPOINT_ROOT}"
     OUTPUT_QUIET
   )
@@ -58,15 +80,19 @@ set(SIM_SOURCES
   sim/src/ota_updater_stub.cpp
   sim/src/http_downloader_stub.cpp
   sim/src/image_to_bmp.cpp
+  sim/src/obfuscation_utils_stub.cpp
+  sim/src/uzlib_checksums_stub.cpp
+  sim/src/webdav_handler_stub.cpp
 )
 
 # Crosspoint application sources (all src/*.cpp); exclude network impls we stub in sim
-file(GLOB_RECURSE CROSSPOINT_SRC "${CROSSPOINT_ROOT}/src/*.cpp")
+file(GLOB_RECURSE CROSSPOINT_SRC CONFIGURE_DEPENDS "${CROSSPOINT_ROOT}/src/*.cpp")
 list(FILTER CROSSPOINT_SRC EXCLUDE REGEX ".*/network/OtaUpdater\\.cpp$")
 list(FILTER CROSSPOINT_SRC EXCLUDE REGEX ".*/network/HttpDownloader\\.cpp$")
+list(FILTER CROSSPOINT_SRC EXCLUDE REGEX ".*/network/WebDAVHandler\\.cpp$")
 
 # Crosspoint libs (exclude hal - we use sim HAL)
-file(GLOB CROSSPOINT_LIB_CPP
+file(GLOB CROSSPOINT_LIB_CPP CONFIGURE_DEPENDS
   "${CROSSPOINT_ROOT}/lib/GfxRenderer/*.cpp"
   "${CROSSPOINT_ROOT}/lib/Epub/*.cpp"
   "${CROSSPOINT_ROOT}/lib/Epub/Epub/*.cpp"
@@ -78,9 +104,16 @@ file(GLOB CROSSPOINT_LIB_CPP
   "${CROSSPOINT_ROOT}/lib/EpdFont/*.cpp"
   "${CROSSPOINT_ROOT}/lib/Utf8/*.cpp"
   "${CROSSPOINT_ROOT}/lib/FsHelpers/*.cpp"
+  "${CROSSPOINT_ROOT}/lib/I18n/*.cpp"
+  "${CROSSPOINT_ROOT}/lib/Logging/*.cpp"
+  "${CROSSPOINT_ROOT}/lib/InflateReader/*.cpp"
+  "${CROSSPOINT_ROOT}/lib/PngToBmpConverter/*.cpp"
   "${CROSSPOINT_ROOT}/lib/ZipFile/*.cpp"
+  "${CROSSPOINT_ROOT}/lib/XmlParserUtils/*.cpp"
+  "${CROSSPOINT_ROOT}/lib/Serialization/*.cpp"
   "${CROSSPOINT_ROOT}/lib/miniz/*.c"
   "${CROSSPOINT_ROOT}/lib/expat/*.c"
+  "${CROSSPOINT_ROOT}/lib/uzlib/src/*.c"
   "${CROSSPOINT_ROOT}/lib/JpegToBmpConverter/*.cpp"
   "${CROSSPOINT_ROOT}/lib/picojpeg/*.c"
   "${CROSSPOINT_ROOT}/lib/KOReaderSync/*.cpp"
@@ -92,10 +125,23 @@ list(FILTER CROSSPOINT_LIB_CPP EXCLUDE REGEX ".*/hal/.*")
 
 # ArduinoJson from PlatformIO libs (if present)
 set(ARDUINO_JSON_ROOT "${CROSSPOINT_ROOT}/.pio/libdeps/default/ArduinoJson")
+set(JPEGDEC_ROOT "${CROSSPOINT_ROOT}/.pio/libdeps/default/JPEGDEC")
+set(PNGDEC_ROOT "${CROSSPOINT_ROOT}/.pio/libdeps/default/PNGdec")
 if(EXISTS "${ARDUINO_JSON_ROOT}/src/ArduinoJson.h")
-  file(GLOB ARDUINO_JSON_SOURCES "${ARDUINO_JSON_ROOT}/src/*.cpp")
+  file(GLOB ARDUINO_JSON_SOURCES CONFIGURE_DEPENDS "${ARDUINO_JSON_ROOT}/src/*.cpp")
   list(APPEND CROSSPOINT_LIB_CPP ${ARDUINO_JSON_SOURCES})
 endif()
+if(EXISTS "${JPEGDEC_ROOT}/src/JPEGDEC.h")
+  file(GLOB JPEGDEC_SOURCES CONFIGURE_DEPENDS "${JPEGDEC_ROOT}/src/*.cpp")
+  list(APPEND CROSSPOINT_LIB_CPP ${JPEGDEC_SOURCES})
+endif()
+if(EXISTS "${PNGDEC_ROOT}/src/PNGdec.h")
+  file(GLOB PNGDEC_CPP_SOURCES CONFIGURE_DEPENDS "${PNGDEC_ROOT}/src/*.cpp")
+  file(GLOB PNGDEC_C_SOURCES CONFIGURE_DEPENDS "${PNGDEC_ROOT}/src/*.c")
+  list(APPEND CROSSPOINT_LIB_CPP ${PNGDEC_CPP_SOURCES} ${PNGDEC_C_SOURCES})
+endif()
+
+list(FILTER CROSSPOINT_LIB_CPP EXCLUDE REGEX ".*/Serialization/ObfuscationUtils\\.cpp$")
 
 add_executable(crosspoint_emulator
   ${SIM_SOURCES}
@@ -114,7 +160,12 @@ target_include_directories(crosspoint_emulator PRIVATE
   ${CROSSPOINT_ROOT}/lib/EpdFont
   ${CROSSPOINT_ROOT}/lib/Utf8
   ${CROSSPOINT_ROOT}/lib/FsHelpers
+  ${CROSSPOINT_ROOT}/lib/I18n
+  ${CROSSPOINT_ROOT}/lib/Logging
+  ${CROSSPOINT_ROOT}/lib/InflateReader
+  ${CROSSPOINT_ROOT}/lib/PngToBmpConverter
   ${CROSSPOINT_ROOT}/lib/ZipFile
+  ${CROSSPOINT_ROOT}/lib/XmlParserUtils
   ${CROSSPOINT_ROOT}/lib/Serialization
   ${CROSSPOINT_ROOT}/lib/JpegToBmpConverter
   ${CROSSPOINT_ROOT}/lib/KOReaderSync
@@ -122,6 +173,7 @@ target_include_directories(crosspoint_emulator PRIVATE
   ${CROSSPOINT_ROOT}/lib/miniz
   ${CROSSPOINT_ROOT}/lib/expat
   ${CROSSPOINT_ROOT}/lib/picojpeg
+  ${CROSSPOINT_ROOT}/lib/uzlib/src
   ${CROSSPOINT_ROOT}/lib/Epub/Epub
   ${CROSSPOINT_ROOT}/lib/Epub/Epub/parsers
   ${CROSSPOINT_ROOT}/lib/Epub/Epub/hyphenation
@@ -129,6 +181,12 @@ target_include_directories(crosspoint_emulator PRIVATE
 
 if(EXISTS "${ARDUINO_JSON_ROOT}/src")
   target_include_directories(crosspoint_emulator PRIVATE ${ARDUINO_JSON_ROOT}/src)
+endif()
+if(EXISTS "${JPEGDEC_ROOT}/src")
+  target_include_directories(crosspoint_emulator PRIVATE ${JPEGDEC_ROOT}/src)
+endif()
+if(EXISTS "${PNGDEC_ROOT}/src")
+  target_include_directories(crosspoint_emulator PRIVATE ${PNGDEC_ROOT}/src)
 endif()
 
 if(SDL2_USE_PKGCONFIG)
@@ -139,8 +197,15 @@ else()
   target_link_libraries(crosspoint_emulator PRIVATE SDL2::SDL2)
 endif()
 
+if(WIN32)
+  target_link_libraries(crosspoint_emulator PRIVATE winhttp)
+  target_compile_options(crosspoint_emulator PRIVATE /FI"${CMAKE_CURRENT_SOURCE_DIR}/sim/include/msvc_compat.h")
+endif()
+
 target_compile_definitions(crosspoint_emulator PRIVATE
   CROSSPOINT_EMULATED=1
+  ENABLE_SERIAL_LOG=1
+  LOG_LEVEL=2
   PROGMEM=
   EINK_DISPLAY_SINGLE_BUFFER_MODE=1
   CROSSPOINT_VERSION="0.16.0-emu"
@@ -149,7 +214,15 @@ target_compile_definitions(crosspoint_emulator PRIVATE
   XML_GE=0
   XML_CONTEXT_BYTES=1024
   USE_UTF8_LONG_NAMES=1
+  RTC_NOINIT_ATTR=
 )
+
+if(WIN32 AND DEFINED SDL2_ROOT AND EXISTS "${SDL2_ROOT}/bin/SDL2.dll")
+  add_custom_command(TARGET crosspoint_emulator POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different
+      "${SDL2_ROOT}/bin/SDL2.dll"
+      "$<TARGET_FILE_DIR:crosspoint_emulator>/SDL2.dll")
+endif()
 
 # main_sim.cpp provides main() and calls setup()/loop() from Crosspoint main.cpp
 # So we must not link a second main - Crosspoint main.cpp does not define main on host

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This allows rapid UI development, testing, and debugging without needing physica
 
 ## Download & Setup
 
-Follow the steps for your operating system below. You need: a **C++17 compiler**, **CMake 3.16+**, **SDL2** (2.x, not SDL3), **Python 3**, **Git**, and the **Crosspoint** repository next to the emulator.
+Follow the steps for your operating system below. You need: a **C++20 compiler**, **CMake 3.16+**, **SDL2** (2.x, not SDL3), **Python 3**, **Git**, and the **Crosspoint** repository next to the emulator.
 
 ### Setup on macOS
 
@@ -304,6 +304,18 @@ The build process:
    ```
 
 4. **Exit**: Close the SDL window (click X or press Alt+F4).
+
+### Control CLI
+
+For automation and repeatable UI checks, the emulator also exposes a machine-readable stdin/stdout control channel:
+
+```bash
+./crosspoint_emulator --control-stdio
+```
+
+Use it to inspect the current screen, wait on UI state transitions, inject semantic text input, trigger screenshots,
+and drive button navigation without timing-only scripts. See [docs/control-stdio.md](docs/control-stdio.md) for the
+command set and JSON event format.
 
 ### Running from Different Directories
 

--- a/docs/control-stdio.md
+++ b/docs/control-stdio.md
@@ -1,0 +1,182 @@
+# Emulator Control Stdio
+
+The emulator supports a persistent machine-readable control channel with `--control-stdio`.
+
+## Start
+
+```powershell
+.\build\Release\crosspoint_emulator.exe --control-stdio
+```
+
+If you need to let delayed UI work complete during automation, you can raise the delay cap:
+
+```powershell
+.\build\Release\crosspoint_emulator.exe --control-stdio --delay-cap-ms 60000
+```
+
+For deterministic test runs, start from a clean emulator session state:
+
+```powershell
+.\build\Release\crosspoint_emulator.exe --control-stdio --reset-session
+```
+
+`--reset-session` clears runtime-generated session data under `sdcard/.crosspoint/` while preserving explicitly
+installed extensions and other manually managed files.
+
+After the first interactive screen is ready, the emulator emits a JSON event prefixed with `[SIMCTL]`:
+
+```text
+[SIMCTL] {"ok":true,"event":"ready","state":{...}}
+```
+
+## Commands
+
+Send one command per line through stdin:
+
+```text
+GET_STATE
+GET_SCREEN
+TYPE_TEXT settings
+WAIT_MS 900
+PRESS DOWN
+RELEASE DOWN
+RELEASE_ALL
+HOLD LEFT 900
+TAP CONFIRM 180
+GO_BACK 10000
+WAIT_ACTIVITY Settings 30000
+WAIT_HEADER Settings 10000
+WAIT_BODY Wi-Fi 10000
+WAIT_LIST_ITEM Settings 15000
+WAIT_MENU_ITEM File Transfer
+WAIT_SELECTED_LIST_ITEM Settings 5000
+WAIT_SELECTED_MENU_ITEM Settings 5000
+WAIT_POPUP Saved 10000
+ACTIVATE_VISIBLE_LIST_ITEM Settings
+ACTIVATE_VISIBLE_MENU_ITEM File Transfer
+SCREENSHOT D:\temp\emu.bmp
+QUIT
+```
+
+## Events
+
+The emulator writes structured responses back to stdout, prefixed with `[SIMCTL]`:
+
+```text
+[SIMCTL] {"ok":true,"event":"state","state":{...}}
+[SIMCTL] {"ok":true,"event":"screen","screen":{...}}
+[SIMCTL] {"ok":true,"event":"text_typed","text":"settings"}
+[SIMCTL] {"ok":true,"event":"wait_started","waitType":"delay","value":"900ms","timeoutMs":900}
+[SIMCTL] {"ok":true,"event":"wait_progress","waitType":"menu_item","value":"File Transfer","elapsedMs":1000,"timeoutMs":30000,"state":{...}}
+[SIMCTL] {"ok":true,"event":"wait_satisfied","waitType":"delay","value":"900","matched":"900ms","state":{...}}
+[SIMCTL] {"ok":true,"event":"action_started","action":"hold","button":"LEFT","durationMs":900}
+[SIMCTL] {"ok":true,"event":"action_completed","action":"hold","value":"","matched":"LEFT","state":{...}}
+[SIMCTL] {"ok":true,"event":"tapped","button":"CONFIRM","durationMs":180}
+[SIMCTL] {"ok":true,"event":"released_all"}
+[SIMCTL] {"ok":true,"event":"action_started","action":"go_back","timeoutMs":10000}
+[SIMCTL] {"ok":true,"event":"action_completed","action":"go_back","matched":"Home","state":{...}}
+[SIMCTL] {"ok":true,"event":"wait_started","waitType":"menu_item","value":"File Transfer","timeoutMs":30000}
+[SIMCTL] {"ok":true,"event":"wait_satisfied","waitType":"menu_item","value":"File Transfer","matched":"File Transfer","state":{...}}
+[SIMCTL] {"ok":true,"event":"action_started","action":"activate_visible_list_item","value":"Settings"}
+[SIMCTL] {"ok":true,"event":"action_completed","action":"activate_visible_list_item","value":"Settings","matched":"Settings","state":{...}}
+[SIMCTL] {"ok":false,"event":"wait_timeout","waitType":"popup","value":"Saved","state":{...}}
+```
+
+## State Shape
+
+The returned `state` object contains:
+
+```json
+{
+  "millis": 1229,
+  "currentActivity": "Home",
+  "pendingAction": "none",
+  "pendingActivity": "",
+  "stackActivities": [],
+  "screen": {
+    "activityName": "Home",
+    "headerTitle": "",
+    "headerSubtitle": "",
+    "subHeaderLabel": "",
+    "subHeaderRightLabel": "",
+    "bodyPrimaryText": "",
+    "bodySecondaryText": "",
+    "bodyTertiaryText": "",
+    "popupMessage": "",
+    "buttonHints": {
+      "btn1": "",
+      "btn2": "Select",
+      "btn3": "Up",
+      "btn4": "Down"
+    },
+    "buttonMenu": {
+      "selectedIndex": 0,
+      "selectedLabel": "Browse Files",
+      "labels": ["Browse Files", "Recent Books", "File Transfer", "Settings"]
+    },
+    "list": {
+      "itemCount": 0,
+      "selectedIndex": -1,
+      "selectedVisibleIndex": -1,
+      "selectedTitle": "",
+      "selectedSubtitle": "",
+      "selectedValue": "",
+      "visibleItems": []
+    }
+  }
+}
+```
+
+`GET_SCREEN` returns only the `screen` object when automation does not need the full process state.
+
+Wait commands use case-insensitive substring matching:
+
+- `WAIT_HEADER` checks `headerTitle` and `headerSubtitle`
+- `WAIT_BODY` checks `bodyPrimaryText`, `bodySecondaryText`, and `bodyTertiaryText`
+- `WAIT_LIST_ITEM` checks visible list item `title`, `subtitle`, and `value`
+- `WAIT_MENU_ITEM` checks `buttonMenu.labels`
+- `WAIT_SELECTED_LIST_ITEM` checks the currently selected visible list item
+- `WAIT_SELECTED_MENU_ITEM` checks `buttonMenu.selectedLabel`
+- `WAIT_POPUP` checks `popupMessage`
+
+`WAIT_*` commands are barriers. If you pipe a full script into stdin, the emulator pauses later queued commands until
+the active wait succeeds or times out. While a wait is still pending, the emulator emits `wait_progress` roughly once
+per second with the latest compact `state`, so CLI harnesses can show what the emulator is currently waiting on instead
+of appearing idle.
+
+Before `ready` is emitted, mutating commands such as `ACTIVATE_VISIBLE_*`, `PRESS`, `TAP`, and `TYPE_TEXT` stay queued
+instead of failing against the transient boot screen. Read-only inspection commands and `WAIT_*` commands still run
+immediately, so a harness can safely begin with waits while startup settles.
+
+Read-only inspection commands still pass through barriers:
+
+- `GET_STATE`
+- `GET_SCREEN`
+- `SCREENSHOT`
+
+`WAIT_MS` is a pure timing barrier for automation flows that need real elapsed time on the emulator, such as testing
+long-press behavior, delayed popups, or background work transitions.
+
+`HOLD <button> <ms>` is a stateful long-press helper. It presses the button immediately, keeps it held for the
+requested duration, then releases it and completes as a barrier event.
+
+`ACTIVATE_VISIBLE_LIST_ITEM` and `ACTIVATE_VISIBLE_MENU_ITEM` are state-driven convenience commands. They navigate step
+by step using the current selected item, wait for selection changes to settle, and only then press confirm. They also
+behave as barriers, so later queued commands will wait until activation completes or fails. For actions that stay on
+the same screen, completion is detected from stable UI state changes such as menu, list, body, or popup updates.
+
+`GO_BACK` is a state-driven back-navigation helper. It taps the back button, waits for the activity or header to
+change, and retries until the target screen changes or the timeout is reached.
+
+`TYPE_TEXT` forwards text semantically to the current activity. Right now this is implemented for
+`KeyboardEntryActivity`, which means automation can fill search, password, or URL prompts without simulating each key
+press.
+
+`RELEASE_ALL` is a safety command for automation harnesses. It clears every held button and cancels queued tap steps,
+which is useful after interrupted long-press or manual `PRESS` testing.
+
+## Notes
+
+- `[SIMCTL]` lines are intended for automation; other log lines may still be present.
+- `--state-json` can still be used in parallel for file-based snapshots.
+- Script-based input remains supported, but new automation should prefer `--control-stdio`.

--- a/sim/include/ArduinoStub.h
+++ b/sim/include/ArduinoStub.h
@@ -4,6 +4,14 @@
 #define PROGMEM
 #endif
 
+#ifndef RTC_NOINIT_ATTR
+#define RTC_NOINIT_ATTR
+#endif
+
+#if defined(_MSC_VER) && !defined(__attribute__)
+#define __attribute__(x)
+#endif
+
 #include <cstdarg>
 #include <cstddef>
 #include <cstdint>
@@ -11,7 +19,9 @@
 #include <cstdlib>
 #include <cstring>
 #include <chrono>
+#include <string>
 #include <thread>
+#include <intrin.h>
 
 // Minimal Arduino-like API for host build
 
@@ -22,10 +32,30 @@ inline unsigned long millis() {
       std::chrono::duration_cast<std::chrono::milliseconds>(now - start).count());
 }
 
-// Cap delay to 1ms in the emulator to keep the UI responsive.
-// On the real device delay(10) saves power; in the sim it just adds latency.
+inline unsigned long micros() {
+  static const auto start = std::chrono::steady_clock::now();
+  auto now = std::chrono::steady_clock::now();
+  return static_cast<unsigned long>(
+      std::chrono::duration_cast<std::chrono::microseconds>(now - start).count());
+}
+
+inline unsigned long simDelayCapMs() {
+  static const unsigned long value = []() -> unsigned long {
+    const char* raw = std::getenv("SIM_DELAY_CAP_MS");
+    if (!raw || !*raw) return 1;
+    char* end = nullptr;
+    const unsigned long parsed = std::strtoul(raw, &end, 10);
+    if (end == raw || *end != '\0') return 1;
+    return parsed;
+  }();
+  return value;
+}
+
+// By default the emulator caps delay() to 1ms to keep the UI responsive.
+// Network and background-job tests can raise this cap through SIM_DELAY_CAP_MS.
 inline void delay(unsigned long ms) {
-  unsigned long capped = ms > 1 ? 1 : ms;
+  const unsigned long capMs = simDelayCapMs();
+  unsigned long capped = ms > capMs ? capMs : ms;
   if (capped > 0) std::this_thread::sleep_for(std::chrono::milliseconds(capped));
 }
 
@@ -41,6 +71,8 @@ inline long random(long min, long max) {
   return min + random(max - min);
 }
 inline void randomSeed(unsigned long) { /* no-op */ }
+
+class String;
 
 class Print {
  public:
@@ -64,6 +96,7 @@ class Print {
 
 class Stream : public Print {
  public:
+  using Print::write;
   virtual int available() { return 0; }
   virtual int read() { return -1; }
   virtual int peek() { return -1; }
@@ -76,6 +109,7 @@ class SerialStub : public Print {
   operator bool() const { return true; }
   int available() const { return 0; }
   int read() { return -1; }
+  String readStringUntil(char);
   size_t write(uint8_t c) override {
     putchar(static_cast<char>(c));
     return 1;
@@ -84,7 +118,11 @@ class SerialStub : public Print {
     for (size_t i = 0; i < size; i++) putchar(static_cast<char>(buf[i]));
     return size;
   }
+#if defined(_MSC_VER)
+  size_t printf(const char* fmt, ...) {
+#else
   size_t printf(const char* fmt, ...) __attribute__((format(printf, 2, 3))) {
+#endif
     va_list args;
     va_start(args, fmt);
     char buf[512];

--- a/sim/include/ESP.h
+++ b/sim/include/ESP.h
@@ -9,6 +9,7 @@ class ESPClass {
   uint32_t getFreeHeap() const { return 8 * 1024 * 1024; }   // 8 MB
   uint32_t getHeapSize() const { return 16 * 1024 * 1024; }   // 16 MB
   uint32_t getMinFreeHeap() const { return 6 * 1024 * 1024; }  // 6 MB
+  uint32_t getMaxAllocHeap() const { return 4 * 1024 * 1024; }  // 4 MB contiguous block
   void restart() { /* no-op in sim */ }
 };
 

--- a/sim/include/FreeRTOSStub.h
+++ b/sim/include/FreeRTOSStub.h
@@ -6,8 +6,11 @@ using TaskHandle_t = void*;
 using SemaphoreHandle_t = void*;
 
 constexpr int pdPASS = 1;
+constexpr int pdTRUE = 1;
+constexpr int pdFALSE = 0;
 constexpr unsigned portMAX_DELAY = 0xFFFFFFFF;
 constexpr int portTICK_PERIOD_MS = 1;
+constexpr int eIncrement = 0;
 
 int xTaskCreate(void (*fn)(void*), const char* name, unsigned stack, void* param, int prio,
                 TaskHandle_t* handle);
@@ -17,3 +20,10 @@ void xSemaphoreTake(SemaphoreHandle_t m, unsigned timeout);
 void xSemaphoreGive(SemaphoreHandle_t m);
 void vSemaphoreDelete(SemaphoreHandle_t m);
 void vTaskDelay(unsigned ms);
+TaskHandle_t xTaskGetCurrentTaskHandle();
+TaskHandle_t xSemaphoreGetMutexHolder(SemaphoreHandle_t m);
+int xTaskNotify(TaskHandle_t h, uint32_t value, int action);
+uint32_t ulTaskNotifyTake(int clearCountOnExit, unsigned timeout);
+int xQueuePeek(SemaphoreHandle_t m, void* out, unsigned timeout);
+inline void taskENTER_CRITICAL(void*) {}
+inline void taskEXIT_CRITICAL(void*) {}

--- a/sim/include/HalDisplay.h
+++ b/sim/include/HalDisplay.h
@@ -23,12 +23,18 @@ class HalDisplay {
   void clearScreen(uint8_t color = 0xFF) const;
   void drawImage(const uint8_t* imageData, uint16_t x, uint16_t y, uint16_t w, uint16_t h,
                  bool fromProgmem = false) const;
+  void drawImageTransparent(const uint8_t* imageData, uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                            bool fromProgmem = false) const;
 
   void displayBuffer(RefreshMode mode = FAST_REFRESH, bool fadingFix = false);
   void refreshDisplay(RefreshMode mode = FAST_REFRESH, bool turnOffScreen = false);
   void deepSleep();
 
   uint8_t* getFrameBuffer() const;
+  uint16_t getDisplayWidth() const { return DISPLAY_WIDTH; }
+  uint16_t getDisplayHeight() const { return DISPLAY_HEIGHT; }
+  uint16_t getDisplayWidthBytes() const { return DISPLAY_WIDTH_BYTES; }
+  uint32_t getBufferSize() const { return BUFFER_SIZE; }
 
   void copyGrayscaleBuffers(const uint8_t* lsbBuffer, const uint8_t* msbBuffer);
   void copyGrayscaleLsbBuffers(const uint8_t* lsbBuffer);
@@ -39,3 +45,5 @@ class HalDisplay {
  private:
   EInkDisplay einkDisplay;
 };
+
+extern HalDisplay display;

--- a/sim/include/HalGPIO.h
+++ b/sim/include/HalGPIO.h
@@ -15,6 +15,8 @@
 
 class HalGPIO {
  public:
+  enum class DeviceType { X3, X4 };
+
   HalGPIO() = default;
 
   void begin();
@@ -35,6 +37,10 @@ class HalGPIO {
   enum class WakeupReason { PowerButton, AfterFlash, AfterUSBPower, Other };
 
   WakeupReason getWakeupReason() const { return WakeupReason::PowerButton; }
+  bool deviceIsX3() const { return deviceType_ == DeviceType::X3; }
+  bool deviceIsX4() const { return deviceType_ == DeviceType::X4; }
+  void verifyPowerButtonWakeup(uint16_t, bool) {}
+  bool wasUsbStateChanged() const { return false; }
 
   static constexpr uint8_t BTN_BACK = 0;
   static constexpr uint8_t BTN_CONFIRM = 1;
@@ -45,9 +51,12 @@ class HalGPIO {
   static constexpr uint8_t BTN_POWER = 6;
 
  private:
+  DeviceType deviceType_ = DeviceType::X4;
   unsigned long pressStartMs_ = 0;
   uint8_t lastState_ = 0;
   uint8_t prevState_ = 0;
   bool anyPressed_ = false;
   bool anyReleased_ = false;
 };
+
+inline HalGPIO gpio;

--- a/sim/include/HalPowerManager.h
+++ b/sim/include/HalPowerManager.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "HalGPIO.h"
+
+class HalPowerManager {
+ public:
+  static constexpr int LOW_POWER_FREQ = 10;
+  static constexpr unsigned long IDLE_POWER_SAVING_MS = 3000;
+  static constexpr unsigned long BATTERY_POLL_MS = 1500;
+
+  void begin() {}
+  void setPowerSaving(bool) {}
+  void startDeepSleep(HalGPIO&) const {}
+  uint16_t getBatteryPercentage() const { return 100; }
+
+  class Lock {
+   public:
+    Lock() = default;
+    ~Lock() = default;
+    Lock(const Lock&) = delete;
+    Lock& operator=(const Lock&) = delete;
+    Lock(Lock&&) = delete;
+    Lock& operator=(Lock&&) = delete;
+  };
+};
+
+inline HalPowerManager powerManager;

--- a/sim/include/HalStorage.h
+++ b/sim/include/HalStorage.h
@@ -10,14 +10,54 @@ class HalStorage {
  public:
   bool begin() { return SdMan.begin(); }
   bool ready() const { return SdMan.ready(); }
+  std::vector<String> listFiles(const char* path = "/", int maxFiles = 200) { return SdMan.listFiles(path, maxFiles); }
+  String readFile(const char* path) { return SdMan.readFile(path); }
+  bool readFileToStream(const char* path, Print& out, size_t chunkSize = 256) {
+    return SdMan.readFileToStream(path, out, chunkSize);
+  }
+  size_t readFileToBuffer(const char* path, char* buffer, size_t bufferSize, size_t maxBytes = 0) {
+    return SdMan.readFileToBuffer(path, buffer, bufferSize, maxBytes);
+  }
+  bool writeFile(const char* path, const String& content) { return SdMan.writeFile(path, content); }
+  bool ensureDirectoryExists(const char* path) { return SdMan.ensureDirectoryExists(path); }
   FsFile open(const char* path, oflag_t oflag = O_RDONLY) { return SdMan.open(path, oflag); }
   bool exists(const char* path) { return SdMan.exists(path); }
   bool mkdir(const char* path, bool pFlag = true) { return SdMan.mkdir(path, pFlag); }
   bool remove(const char* path) { return SdMan.remove(path); }
+  bool rename(const char* oldPath, const char* newPath) {
+    FsFile file = SdMan.open(oldPath, O_RDWR);
+    if (!file) return false;
+    const bool ok = file.rename(newPath);
+    file.close();
+    return ok;
+  }
   bool rmdir(const char* path) { return SdMan.rmdir(path); }
+  bool openFileForRead(const char* moduleName, const char* path, FsFile& file) {
+    return SdMan.openFileForRead(moduleName, path, file);
+  }
+  bool openFileForRead(const char* moduleName, const std::string& path, FsFile& file) {
+    return SdMan.openFileForRead(moduleName, path, file);
+  }
+  bool openFileForRead(const char* moduleName, const String& path, FsFile& file) {
+    return SdMan.openFileForRead(moduleName, path, file);
+  }
+  bool openFileForWrite(const char* moduleName, const char* path, FsFile& file) {
+    return SdMan.openFileForWrite(moduleName, path, file);
+  }
+  bool openFileForWrite(const char* moduleName, const std::string& path, FsFile& file) {
+    return SdMan.openFileForWrite(moduleName, path, file);
+  }
+  bool openFileForWrite(const char* moduleName, const String& path, FsFile& file) {
+    return SdMan.openFileForWrite(moduleName, path, file);
+  }
+  bool removeDir(const char* path) { return SdMan.removeDir(path); }
 
   static HalStorage& getInstance() {
     static HalStorage s;
     return s;
   }
 };
+
+#ifndef Storage
+#define Storage HalStorage::getInstance()
+#endif

--- a/sim/include/HalSystem.h
+++ b/sim/include/HalSystem.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace HalSystem {
+struct StackFrame {
+  uint32_t sp = 0;
+  uint32_t spp[8] = {};
+};
+
+inline void begin() {}
+inline void checkPanic() {}
+inline void clearPanic() {}
+inline std::string getPanicInfo(bool = false) { return {}; }
+inline bool isRebootFromPanic() { return false; }
+}  // namespace HalSystem

--- a/sim/include/HardwareSerial.h
+++ b/sim/include/HardwareSerial.h
@@ -1,3 +1,6 @@
 #pragma once
 // Stub for Arduino HardwareSerial; Serial is defined in ArduinoStub.h
 #include "ArduinoStub.h"
+
+using HWCDC = SerialStub;
+using HardwareSerial = SerialStub;

--- a/sim/include/NetworkUdp.h
+++ b/sim/include/NetworkUdp.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "WiFiUdp.h"
+
+using NetworkUDP = WiFiUDP;

--- a/sim/include/SdFat.h
+++ b/sim/include/SdFat.h
@@ -33,6 +33,8 @@ class FsFile : public Stream {
   int peek() override;
   size_t write(uint8_t c) override;
   size_t write(const uint8_t* buf, size_t size) override;
+  size_t write(const void* buf, size_t size) { return write(reinterpret_cast<const uint8_t*>(buf), size); }
+  size_t write(const char* buf, size_t size) { return write(reinterpret_cast<const uint8_t*>(buf), size); }
   size_t print(const class String& s);
   int available() override;
   bool isDirectory() const { return isDir_; }
@@ -44,6 +46,7 @@ class FsFile : public Stream {
   bool seekCur(int32_t offset);
   uint32_t position() const;
   size_t fileSize() const { return size(); }
+  bool isOpen() const { return fp_ != nullptr || dir_ != nullptr; }
   void setCurrentName(const std::string& name) { currentName_ = name; }
   FsFile openNextFile();
   bool rename(const char* newPath);

--- a/sim/include/WString.h
+++ b/sim/include/WString.h
@@ -10,10 +10,13 @@ class String : public Print {
   String(const char* c) : s_(c ? c : ""), readPos_(0) {}
   String(const std::string& s) : s_(s), readPos_(0) {}
   String(char c) : s_(1, c), readPos_(0) {}
+  String(signed char c) : s_(1, static_cast<char>(c)), readPos_(0) {}
+  String(unsigned char c) : s_(1, static_cast<char>(c)), readPos_(0) {}
   String(int n) : s_(std::to_string(n)), readPos_(0) {}
   String(unsigned n) : s_(std::to_string(n)), readPos_(0) {}
   String(long n) : s_(std::to_string(n)), readPos_(0) {}
   String(unsigned long n) : s_(std::to_string(n)), readPos_(0) {}
+  String(size_t n) : s_(std::to_string(n)), readPos_(0) {}
 
   // Stream-like read for ArduinoJson deserializeJson(doc, string)
   int read() {
@@ -51,6 +54,8 @@ class String : public Print {
     if (s_.empty()) return 0;
     return std::stol(s_, nullptr, 0);
   }
+  char operator[](size_t index) const { return index < s_.size() ? s_[index] : '\0'; }
+  char& operator[](size_t index) { return s_[index]; }
 
   String& operator=(const char* c) {
     s_ = c ? c : "";
@@ -103,6 +108,26 @@ class String : public Print {
     size_t end = s_.find_last_not_of(" \t\r\n");
     s_ = s_.substr(start, end == std::string::npos ? std::string::npos : end - start + 1);
   }
+
+  void replace(const char* find, const char* replacement) {
+    if (!find || !*find) return;
+    const std::string repl = replacement ? replacement : "";
+    size_t pos = 0;
+    const size_t findLen = std::strlen(find);
+    while ((pos = s_.find(find, pos)) != std::string::npos) {
+      s_.replace(pos, findLen, repl);
+      pos += repl.size();
+    }
+  }
+
+  void replace(size_t index, size_t count, const char* replacement) {
+    s_.replace(index, count, replacement ? replacement : "");
+  }
+
+  friend bool operator<(const String& a, const String& b) { return a.s_ < b.s_; }
+  friend bool operator>(const String& a, const String& b) { return a.s_ > b.s_; }
+  friend bool operator<=(const String& a, const String& b) { return a.s_ <= b.s_; }
+  friend bool operator>=(const String& a, const String& b) { return a.s_ >= b.s_; }
 
   std::string& str() { return s_; }
   const std::string& str() const { return s_; }

--- a/sim/include/WebServer.h
+++ b/sim/include/WebServer.h
@@ -4,11 +4,38 @@
 #include "WiFiClient.h"
 
 #include <functional>
+#include <memory>
+#include <vector>
 
-enum { HTTP_GET, HTTP_POST };
+enum HTTPMethod {
+  HTTP_ANY,
+  HTTP_GET,
+  HTTP_POST,
+  HTTP_DELETE,
+  HTTP_PUT,
+  HTTP_PATCH,
+  HTTP_HEAD,
+  HTTP_OPTIONS,
+  HTTP_PROPFIND,
+  HTTP_MKCOL,
+  HTTP_MOVE,
+  HTTP_COPY,
+  HTTP_LOCK,
+  HTTP_UNLOCK
+};
+
 constexpr int CONTENT_LENGTH_UNKNOWN = -1;
 
 enum { UPLOAD_FILE_START, UPLOAD_FILE_WRITE, UPLOAD_FILE_END, UPLOAD_FILE_ABORTED };
+
+struct HTTPRaw {
+  uint8_t* buf = nullptr;
+  size_t size = 0;
+  size_t currentSize = 0;
+  size_t totalSize = 0;
+  bool isFirst = false;
+  bool isFinal = false;
+};
 
 struct HTTPUpload {
   int status = UPLOAD_FILE_ABORTED;
@@ -21,21 +48,54 @@ struct HTTPUpload {
   const uint8_t* buf = nullptr;
 };
 
+class RequestHandler {
+ public:
+  virtual ~RequestHandler() = default;
+  virtual bool canHandle(class WebServer& server, HTTPMethod method, const String& uri) {
+    (void)server;
+    (void)method;
+    (void)uri;
+    return false;
+  }
+  virtual bool canRaw(class WebServer& server, const String& uri) {
+    (void)server;
+    (void)uri;
+    return false;
+  }
+  virtual void raw(class WebServer& server, const String& uri, HTTPRaw& raw) {
+    (void)server;
+    (void)uri;
+    (void)raw;
+  }
+  virtual bool handle(class WebServer& server, HTTPMethod method, const String& uri) {
+    (void)server;
+    (void)method;
+    (void)uri;
+    return false;
+  }
+};
+
 class WebServer {
  public:
   explicit WebServer(uint16_t port) : port_(port) {}
-  void on(const char* path, int method, std::function<void()> fn) { (void)path; (void)method; (void)fn; }
-  void on(const char* path, int method, std::function<void()> uploadFn, std::function<void()> bodyFn) {
+  void on(const char* path, HTTPMethod method, std::function<void()> fn) { (void)path; (void)method; (void)fn; }
+  void on(const char* path, HTTPMethod method, std::function<void()> uploadFn, std::function<void()> bodyFn) {
     (void)path; (void)method; (void)uploadFn; (void)bodyFn;
   }
   void onNotFound(std::function<void()> fn) { (void)fn; }
   void begin() {}
   void stop() {}
   void handleClient() {}
+  void addHandler(RequestHandler* handler) { handlers_.emplace_back(handler); }
+  void collectHeaders(const char*[], size_t) {}
   void send(int code, const char* type, const char* content) { (void)code; (void)type; (void)content; }
   void send(int code, const char* type, const String& content) { (void)code; (void)type; (void)content; }
+  void send(int code) { (void)code; }
   void sendContent(const char* content) { (void)content; }
   void sendContent(const String& content) { (void)content; }
+  void send_P(int code, const char* type, const char* content, size_t len) {
+    (void)code; (void)type; (void)content; (void)len;
+  }
   void sendHeader(const char* name, const char* value, bool first = false) {
     (void)name;
     (void)value;
@@ -51,9 +111,13 @@ class WebServer {
   bool hasArg(const char* name) const { (void)name; return false; }
   String arg(const char* name) const { (void)name; return String(""); }
   String uri() const { return String(""); }
+  String header(const char* name) const { (void)name; return String(""); }
+  HTTPMethod method() const { return HTTP_GET; }
+  size_t clientContentLength() const { return 0; }
   const HTTPUpload& upload() const { return upload_; }
 
  private:
   uint16_t port_;
   HTTPUpload upload_;
+  std::vector<std::unique_ptr<RequestHandler>> handlers_;
 };

--- a/sim/include/WiFi.h
+++ b/sim/include/WiFi.h
@@ -45,8 +45,9 @@ enum { WIFI_AUTH_OPEN = 0 };
 class WiFiClass {
  public:
   void mode(int) {}
-  wl_status_t status() const { return WL_DISCONNECTED; }
-  void disconnect(bool = true) {}
+  void persistent(bool) {}
+  wl_status_t status() const { return WL_CONNECTED; }
+  void disconnect(bool = true, bool = false) {}
   void softAPdisconnect(bool = true) {}
   bool softAP(const char* ssid, const char* pass = nullptr, int = 1, bool = false, int = 4) {
     (void)ssid;
@@ -54,19 +55,21 @@ class WiFiClass {
     return false;  // no-op in sim
   }
   IPAddress softAPIP() const { return IPAddress(192, 168, 4, 1); }
-  IPAddress localIP() const { return IPAddress(0, 0, 0, 0); }
-  String SSID() const { return String(""); }
+  IPAddress localIP() const { return IPAddress(127, 0, 0, 1); }
+  String SSID() const { return String("Crosspoint-Emulator"); }
   String SSID(int i) const {
     (void)i;
     return String("");
   }
-  wifi_mode_t getMode() const { return WIFI_MODE_NULL; }
-  String getHostname() const { return String(""); }
+  wifi_mode_t getMode() const { return WIFI_MODE_STA; }
+  String getHostname() const { return String("crosspoint-emulator"); }
+  bool setHostname(const char*) { return true; }
   void setSleep(bool) {}
   int softAPgetStationNum() const { return 0; }
   void macAddress(uint8_t* mac) {
     for (int i = 0; i < 6; i++) mac[i] = 0;
   }
+  String macAddress() const { return String("00:00:00:00:00:00"); }
   void scanDelete() {}
   int16_t scanNetworks(bool = false) { return 0; }
   int16_t scanComplete() { return 0; }
@@ -82,7 +85,7 @@ class WiFiClass {
   bool begin(const char* ssid, const char* pass = nullptr) {
     (void)ssid;
     (void)pass;
-    return false;
+    return true;
   }
 };
 

--- a/sim/include/WiFiClient.h
+++ b/sim/include/WiFiClient.h
@@ -7,8 +7,9 @@ class WiFiClient : public Stream {
   int connect(const char* host, uint16_t port) { (void)host; (void)port; return 0; }
   void stop() {}
   bool connected() { return false; }
-  size_t write(uint8_t c) override { (void)c; return 0; }
-  size_t write(const uint8_t* buf, size_t size) override { (void)buf; (void)size; return 0; }
+  void clear() {}
+  size_t write(uint8_t c) override { (void)c; return 1; }
+  size_t write(const uint8_t* buf, size_t size) override { (void)buf; return size; }
   size_t write(Stream& stream) {
     size_t n = 0;
     while (stream.available()) {
@@ -19,3 +20,5 @@ class WiFiClient : public Stream {
     return n;
   }
 };
+
+using NetworkClient = WiFiClient;

--- a/sim/include/esp_system.h
+++ b/sim/include/esp_system.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include <cstdint>
+
+inline uint32_t esp_get_free_heap_size() { return 0; }

--- a/sim/include/msvc_compat.h
+++ b/sim/include/msvc_compat.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#ifdef _MSC_VER
+#ifdef __cplusplus
+#include <cstring>
+#else
+#include <string.h>
+#endif
+#include <intrin.h>
+
+#ifndef memcpy_P
+#define memcpy_P(dest, src, n) memcpy((dest), (src), (n))
+#endif
+
+#ifndef __builtin_bswap16
+#define __builtin_bswap16 _byteswap_ushort
+#endif
+
+#ifndef uint
+typedef unsigned int uint;
+#endif
+#endif

--- a/sim/include/qrcode.h
+++ b/sim/include/qrcode.h
@@ -1,18 +1,65 @@
 #pragma once
 
 #include <cstdint>
+#include <cstring>
 
-enum { ECC_LOW };
-
-struct QRCode {
-  uint8_t size;
+enum {
+  MODE_NUMERIC = 0,
+  MODE_ALPHANUMERIC = 1,
+  MODE_BYTE = 2,
 };
 
-int qrcode_getBufferSize(int version) { (void)version; return 200; }
-void qrcode_initText(struct QRCode* qrcode, uint8_t* buffers, int version, int ecc, const char* text) {
-  (void)qrcode; (void)buffers; (void)version; (void)ecc; (void)text;
-  qrcode->size = 0;
+enum {
+  ECC_LOW = 0,
+  ECC_MEDIUM = 1,
+  ECC_QUARTILE = 2,
+  ECC_HIGH = 3,
+};
+
+struct QRCode {
+  uint8_t version;
+  uint8_t size;
+  uint8_t ecc;
+  uint8_t mode;
+  uint8_t mask;
+  uint8_t* modules;
+};
+
+inline uint16_t qrcode_getBufferSize(uint8_t version) {
+  const uint8_t size = static_cast<uint8_t>(version * 4 + 17);
+  return static_cast<uint16_t>(size) * static_cast<uint16_t>(size);
 }
-bool qrcode_getModule(const struct QRCode* qrcode, int x, int y) {
-  (void)qrcode; (void)x; (void)y; return false;
+
+inline int8_t qrcode_initText(QRCode* qrcode, uint8_t* buffers, uint8_t version, uint8_t ecc, const char* text) {
+  if (!qrcode || !buffers) return -1;
+  qrcode->version = version;
+  qrcode->size = static_cast<uint8_t>(version * 4 + 17);
+  qrcode->ecc = ecc;
+  qrcode->mode = MODE_BYTE;
+  qrcode->mask = 0;
+  qrcode->modules = buffers;
+
+  const size_t total = static_cast<size_t>(qrcode->size) * static_cast<size_t>(qrcode->size);
+  std::memset(buffers, 0, total);
+
+  const size_t seedLen = text ? std::strlen(text) : 0;
+  for (uint8_t y = 0; y < qrcode->size; ++y) {
+    for (uint8_t x = 0; x < qrcode->size; ++x) {
+      const bool border = (x < 7 && y < 7) || (x >= qrcode->size - 7 && y < 7) || (x < 7 && y >= qrcode->size - 7);
+      const bool pattern = ((x * 3 + y * 5 + seedLen) % 7) < 3;
+      buffers[static_cast<size_t>(y) * qrcode->size + x] = static_cast<uint8_t>(border || pattern);
+    }
+  }
+
+  return 0;
+}
+
+inline int8_t qrcode_initBytes(QRCode* qrcode, uint8_t* buffers, uint8_t version, uint8_t ecc, uint8_t* data,
+                               uint16_t) {
+  return qrcode_initText(qrcode, buffers, version, ecc, reinterpret_cast<const char*>(data));
+}
+
+inline bool qrcode_getModule(const QRCode* qrcode, uint8_t x, uint8_t y) {
+  if (!qrcode || !qrcode->modules || x >= qrcode->size || y >= qrcode->size) return false;
+  return qrcode->modules[static_cast<size_t>(y) * qrcode->size + x] != 0;
 }

--- a/sim/include/sim_display.h
+++ b/sim/include/sim_display.h
@@ -5,3 +5,4 @@ bool sim_display_init(void);
 void sim_display_shutdown(void);
 // Process SDL events (keyboard, etc.). Returns false if user requested quit.
 bool sim_display_pump_events(void);
+bool sim_display_save_screenshot(const char* path);

--- a/sim/include/sim_gpio_control.h
+++ b/sim/include/sim_gpio_control.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+bool sim_gpio_try_parse_button(const std::string& name, uint8_t& outButton);
+const char* sim_gpio_button_name(uint8_t button);
+void sim_gpio_press_button(uint8_t button);
+void sim_gpio_release_button(uint8_t button);
+void sim_gpio_release_all_buttons();
+void sim_gpio_tap_button(uint8_t button, unsigned long durationMs);
+void sim_gpio_queue_tap_button(uint8_t button, unsigned long durationMs, unsigned long delayMs);

--- a/sim/src/arduino_stub.cpp
+++ b/sim/src/arduino_stub.cpp
@@ -1,5 +1,8 @@
 #include "ArduinoStub.h"
 #include "SPI.h"
+#include "WString.h"
 
 SerialStub Serial;
 SPIClass SPI;
+
+String SerialStub::readStringUntil(char) { return String(""); }

--- a/sim/src/freertos_stub.cpp
+++ b/sim/src/freertos_stub.cpp
@@ -1,28 +1,11 @@
 #include "FreeRTOSStub.h"
 
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+#include <stdexcept>
 #include <thread>
 #include <unordered_map>
-#include <mutex>
-#include <atomic>
-#include <stdexcept>
-
-// ---------------------------------------------------------------------------
-// Sim FreeRTOS stub
-//
-// Key challenge: on real FreeRTOS, vTaskDelete() kills a task immediately,
-// even if it is blocked on a semaphore. std::thread has no such mechanism,
-// so we must make every blocking point *cooperative* — the task periodically
-// checks whether it has been cancelled and throws TaskExit to unwind.
-//
-// Deadlock scenario this solves:
-//   1. Main thread: xSemaphoreTake(renderingMutex)     — holds the mutex
-//   2. Main thread: vTaskDelete(displayTaskHandle)      — sets cancelled, join()s
-//   3. Display task: xSemaphoreTake(renderingMutex)     — would block forever
-//
-// Fix: xSemaphoreTake uses try_lock() in a loop, checking cancelled between
-// attempts. When cancelled, it throws TaskExit so the thread exits and
-// join() returns.
-// ---------------------------------------------------------------------------
 
 namespace {
 
@@ -31,36 +14,45 @@ struct TaskExit : std::exception {};
 struct TaskInfo {
   std::thread thread;
   std::atomic<bool> cancelled{false};
+  std::mutex notifyMutex;
+  std::condition_variable notifyCv;
+  uint32_t notifyCount = 0;
 };
+
+struct MutexInfo {
+  std::mutex mutex;
+  std::atomic<TaskHandle_t> owner{nullptr};
+};
+
 std::unordered_map<TaskHandle_t, TaskInfo*> s_tasks;
 std::mutex s_mutex;
+uintptr_t s_mainTaskStorage = 0;
+TaskHandle_t s_mainTaskHandle = reinterpret_cast<TaskHandle_t>(&s_mainTaskStorage);
 
 thread_local TaskHandle_t t_currentHandle = nullptr;
 thread_local TaskInfo* t_currentInfo = nullptr;
 
-// Check if the current task has been cancelled and throw if so.
 inline void checkCancelled() {
-  if (t_currentInfo && t_currentInfo->cancelled.load())
+  if (t_currentInfo && t_currentInfo->cancelled.load()) {
     throw TaskExit();
+  }
 }
 
 }  // namespace
 
 void vTaskDelay(unsigned ms) {
   checkCancelled();
-  // Sleep in small increments so cancellation is noticed quickly.
   constexpr unsigned SLICE_MS = 5;
   unsigned remaining = ms;
   while (remaining > 0) {
-    unsigned sleepMs = remaining < SLICE_MS ? remaining : SLICE_MS;
+    const unsigned sleepMs = remaining < SLICE_MS ? remaining : SLICE_MS;
     std::this_thread::sleep_for(std::chrono::milliseconds(sleepMs));
     remaining -= sleepMs;
     checkCancelled();
   }
 }
 
-int xTaskCreate(void (*fn)(void*), const char*, unsigned, void* param, int,
-                TaskHandle_t* handle) {
+int xTaskCreate(void (*fn)(void*), const char*, unsigned, void* param, int, TaskHandle_t* handle) {
   auto h = reinterpret_cast<TaskHandle_t>(new uintptr_t(0));
   auto* info = new TaskInfo();
   {
@@ -72,11 +64,14 @@ int xTaskCreate(void (*fn)(void*), const char*, unsigned, void* param, int,
     t_currentInfo = info;
     try {
       fn(param);
-    } catch (const TaskExit&) {}
+    } catch (const TaskExit&) {
+    }
     t_currentHandle = nullptr;
     t_currentInfo = nullptr;
   });
-  if (handle) *handle = h;
+  if (handle) {
+    *handle = h;
+  }
   return pdPASS;
 }
 
@@ -92,41 +87,112 @@ void vTaskDelete(TaskHandle_t h) {
     }
   }
   if (info) {
-    // Signal cancellation — the task will see this in vTaskDelay or xSemaphoreTake.
     info->cancelled.store(true);
-    if (info->thread.joinable())
+    info->notifyCv.notify_all();
+    if (info->thread.joinable()) {
       info->thread.join();
+    }
     delete info;
   }
   delete reinterpret_cast<uintptr_t*>(h);
 }
 
 SemaphoreHandle_t xSemaphoreCreateMutex() {
-  return reinterpret_cast<SemaphoreHandle_t>(new std::mutex);
+  return reinterpret_cast<SemaphoreHandle_t>(new MutexInfo());
 }
 
 void xSemaphoreTake(SemaphoreHandle_t m, unsigned) {
-  auto* mtx = m ? static_cast<std::mutex*>(m) : nullptr;
+  auto* mtx = m ? static_cast<MutexInfo*>(m) : nullptr;
   if (!mtx) return;
+  const TaskHandle_t owner = t_currentHandle ? t_currentHandle : s_mainTaskHandle;
 
-  // Main thread (no task context) — just lock normally.
   if (!t_currentInfo) {
-    mtx->lock();
+    mtx->mutex.lock();
+    mtx->owner.store(owner);
     return;
   }
 
-  // Task thread — spin on try_lock with cancellation checks so we never
-  // block permanently on a mutex held by the thread that is join()ing us.
-  while (!mtx->try_lock()) {
+  while (!mtx->mutex.try_lock()) {
     checkCancelled();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
   }
+  mtx->owner.store(owner);
 }
 
 void xSemaphoreGive(SemaphoreHandle_t m) {
-  if (m) static_cast<std::mutex*>(m)->unlock();
+  auto* mtx = m ? static_cast<MutexInfo*>(m) : nullptr;
+  if (!mtx) return;
+  mtx->owner.store(nullptr);
+  mtx->mutex.unlock();
 }
 
 void vSemaphoreDelete(SemaphoreHandle_t m) {
-  delete static_cast<std::mutex*>(m);
+  delete static_cast<MutexInfo*>(m);
+}
+
+TaskHandle_t xTaskGetCurrentTaskHandle() {
+  return t_currentHandle ? t_currentHandle : s_mainTaskHandle;
+}
+
+TaskHandle_t xSemaphoreGetMutexHolder(SemaphoreHandle_t m) {
+  auto* mtx = m ? static_cast<MutexInfo*>(m) : nullptr;
+  return mtx ? mtx->owner.load() : nullptr;
+}
+
+int xTaskNotify(TaskHandle_t h, uint32_t value, int) {
+  TaskInfo* info = nullptr;
+  {
+    std::lock_guard<std::mutex> lock(s_mutex);
+    auto it = s_tasks.find(h);
+    if (it != s_tasks.end()) {
+      info = it->second;
+    }
+  }
+  if (!info) return pdFALSE;
+  {
+    std::lock_guard<std::mutex> lock(info->notifyMutex);
+    info->notifyCount += value;
+  }
+  info->notifyCv.notify_all();
+  return pdPASS;
+}
+
+uint32_t ulTaskNotifyTake(int clearCountOnExit, unsigned timeout) {
+  if (!t_currentInfo) return 0;
+
+  std::unique_lock<std::mutex> lock(t_currentInfo->notifyMutex);
+  auto hasNotification = [info = t_currentInfo]() { return info->notifyCount > 0 || info->cancelled.load(); };
+
+  if (timeout == portMAX_DELAY) {
+    t_currentInfo->notifyCv.wait(lock, hasNotification);
+  } else {
+    t_currentInfo->notifyCv.wait_for(lock, std::chrono::milliseconds(timeout), hasNotification);
+  }
+
+  if (t_currentInfo->cancelled.load()) {
+    lock.unlock();
+    checkCancelled();
+    return 0;
+  }
+
+  const uint32_t current = t_currentInfo->notifyCount;
+  if (current == 0) return 0;
+
+  if (clearCountOnExit) {
+    t_currentInfo->notifyCount = 0;
+    return current;
+  }
+
+  t_currentInfo->notifyCount--;
+  return current;
+}
+
+int xQueuePeek(SemaphoreHandle_t m, void*, unsigned) {
+  auto* mtx = m ? static_cast<MutexInfo*>(m) : nullptr;
+  if (!mtx) return pdFALSE;
+  if (mtx->mutex.try_lock()) {
+    mtx->mutex.unlock();
+    return pdTRUE;
+  }
+  return pdFALSE;
 }

--- a/sim/src/http_downloader_stub.cpp
+++ b/sim/src/http_downloader_stub.cpp
@@ -1,21 +1,243 @@
-// Stub implementation of HttpDownloader for emulator (no HTTP in sim).
 #include "network/HttpDownloader.h"
 
-bool HttpDownloader::fetchUrl(const std::string& url, std::string& outContent) {
+#include "HalStorage.h"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#include <winhttp.h>
+#pragma comment(lib, "winhttp.lib")
+#endif
+
+namespace {
+#ifdef _WIN32
+std::wstring toWide(const std::string& value) {
+  if (value.empty()) return std::wstring();
+  const int len = MultiByteToWideChar(CP_UTF8, 0, value.c_str(), -1, nullptr, 0);
+  std::wstring out(static_cast<size_t>(len), L'\0');
+  MultiByteToWideChar(CP_UTF8, 0, value.c_str(), -1, out.data(), len);
+  if (!out.empty() && out.back() == L'\0') out.pop_back();
+  return out;
+}
+
+std::string base64Encode(const std::string& input) {
+  static constexpr char kBase64Table[] =
+      "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+  std::string out;
+  int val = 0;
+  int valb = -6;
+  for (unsigned char c : input) {
+    val = (val << 8) + c;
+    valb += 8;
+    while (valb >= 0) {
+      out.push_back(kBase64Table[(val >> valb) & 0x3F]);
+      valb -= 6;
+    }
+  }
+  if (valb > -6) out.push_back(kBase64Table[((val << 8) >> (valb + 8)) & 0x3F]);
+  while (out.size() % 4) out.push_back('=');
+  return out;
+}
+
+bool downloadWithWinHttp(const std::string& url, const std::string& username, const std::string& password,
+                         const std::function<bool(const uint8_t*, size_t, size_t, size_t)>& onChunk) {
+  URL_COMPONENTS parts{};
+  wchar_t host[256] = {};
+  wchar_t path[2048] = {};
+  parts.dwStructSize = sizeof(parts);
+  parts.lpszHostName = host;
+  parts.dwHostNameLength = static_cast<DWORD>(std::size(host));
+  parts.lpszUrlPath = path;
+  parts.dwUrlPathLength = static_cast<DWORD>(std::size(path));
+
+  std::wstring wideUrl = toWide(url);
+  if (!WinHttpCrackUrl(wideUrl.c_str(), 0, 0, &parts)) {
+    return false;
+  }
+
+  const bool secure = parts.nScheme == INTERNET_SCHEME_HTTPS;
+  HINTERNET session = WinHttpOpen(L"Crosspoint-Emulator/1.0", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
+                                  WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
+  if (!session) return false;
+
+  HINTERNET connect = WinHttpConnect(session, std::wstring(parts.lpszHostName, parts.dwHostNameLength).c_str(),
+                                     parts.nPort, 0);
+  if (!connect) {
+    WinHttpCloseHandle(session);
+    return false;
+  }
+
+  HINTERNET request = WinHttpOpenRequest(connect, L"GET", std::wstring(parts.lpszUrlPath, parts.dwUrlPathLength).c_str(),
+                                         nullptr, WINHTTP_NO_REFERER, WINHTTP_DEFAULT_ACCEPT_TYPES,
+                                         secure ? WINHTTP_FLAG_SECURE : 0);
+  if (!request) {
+    WinHttpCloseHandle(connect);
+    WinHttpCloseHandle(session);
+    return false;
+  }
+
+  DWORD redirectPolicy = WINHTTP_OPTION_REDIRECT_POLICY_ALWAYS;
+  WinHttpSetOption(request, WINHTTP_OPTION_REDIRECT_POLICY, &redirectPolicy, sizeof(redirectPolicy));
+
+  std::wstring extraHeaders =
+      L"Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8\r\n"
+      L"Accept-Language: vi-VN,vi;q=0.9,en-US;q=0.8,en;q=0.7\r\n"
+      L"Cache-Control: no-cache\r\n"
+      L"Pragma: no-cache\r\n";
+  if (!username.empty() || !password.empty()) {
+    extraHeaders += toWide("Authorization: Basic " + base64Encode(username + ":" + password) + "\r\n");
+  }
+
+  const bool sent = WinHttpSendRequest(request,
+                                       extraHeaders.empty() ? WINHTTP_NO_ADDITIONAL_HEADERS : extraHeaders.c_str(),
+                                       extraHeaders.empty() ? 0 : static_cast<DWORD>(-1L), WINHTTP_NO_REQUEST_DATA, 0, 0, 0) &&
+                    WinHttpReceiveResponse(request, nullptr);
+  if (!sent) {
+    WinHttpCloseHandle(request);
+    WinHttpCloseHandle(connect);
+    WinHttpCloseHandle(session);
+    return false;
+  }
+
+  DWORD statusCode = 0;
+  DWORD statusSize = sizeof(statusCode);
+  if (!WinHttpQueryHeaders(request, WINHTTP_QUERY_STATUS_CODE | WINHTTP_QUERY_FLAG_NUMBER, WINHTTP_HEADER_NAME_BY_INDEX,
+                           &statusCode, &statusSize, WINHTTP_NO_HEADER_INDEX) ||
+      statusCode < 200 || statusCode >= 300) {
+    WinHttpCloseHandle(request);
+    WinHttpCloseHandle(connect);
+    WinHttpCloseHandle(session);
+    return false;
+  }
+
+  unsigned long long contentLengthValue = 0;
+  DWORD contentLengthSize = sizeof(contentLengthValue);
+  size_t totalBytes = 0;
+  if (WinHttpQueryHeaders(request,
+                          WINHTTP_QUERY_CONTENT_LENGTH | WINHTTP_QUERY_FLAG_NUMBER,
+                          WINHTTP_HEADER_NAME_BY_INDEX,
+                          &contentLengthValue,
+                          &contentLengthSize,
+                          WINHTTP_NO_HEADER_INDEX)) {
+    totalBytes = static_cast<size_t>(contentLengthValue);
+  }
+
+  std::vector<uint8_t> buffer(16 * 1024);
+  size_t downloaded = 0;
+  while (true) {
+    DWORD available = 0;
+    if (!WinHttpQueryDataAvailable(request, &available)) {
+      WinHttpCloseHandle(request);
+      WinHttpCloseHandle(connect);
+      WinHttpCloseHandle(session);
+      return false;
+    }
+    if (available == 0) break;
+
+    DWORD toRead = std::min<DWORD>(available, static_cast<DWORD>(buffer.size()));
+    DWORD read = 0;
+    if (!WinHttpReadData(request, buffer.data(), toRead, &read)) {
+      WinHttpCloseHandle(request);
+      WinHttpCloseHandle(connect);
+      WinHttpCloseHandle(session);
+      return false;
+    }
+    if (read == 0) break;
+    downloaded += read;
+    if (!onChunk(buffer.data(), read, downloaded, totalBytes)) {
+      WinHttpCloseHandle(request);
+      WinHttpCloseHandle(connect);
+      WinHttpCloseHandle(session);
+      return false;
+    }
+  }
+
+  WinHttpCloseHandle(request);
+  WinHttpCloseHandle(connect);
+  WinHttpCloseHandle(session);
+  return true;
+}
+#endif
+}  // namespace
+
+bool HttpDownloader::fetchUrl(const std::string& url, std::string& outContent, const std::string& username,
+                              const std::string& password) {
+#ifdef _WIN32
+  outContent.clear();
+  return downloadWithWinHttp(url, username, password,
+                             [&outContent](const uint8_t* data, size_t size, size_t, size_t) {
+                               outContent.append(reinterpret_cast<const char*>(data), size);
+                               return true;
+                             });
+#else
   (void)url;
   (void)outContent;
+  (void)username;
+  (void)password;
   return false;
+#endif
 }
-bool HttpDownloader::fetchUrl(const std::string& url, Stream& stream) {
+
+bool HttpDownloader::fetchUrl(const std::string& url, Stream& stream, const std::string& username,
+                              const std::string& password) {
+#ifdef _WIN32
+  return downloadWithWinHttp(url, username, password,
+                             [&stream](const uint8_t* data, size_t size, size_t, size_t) {
+                               size_t written = 0;
+                               while (written < size) {
+                                 const size_t chunk = stream.write(data + written, size - written);
+                                 if (chunk == 0) return false;
+                                 written += chunk;
+                               }
+                               return true;
+                             });
+#else
   (void)url;
   (void)stream;
+  (void)username;
+  (void)password;
   return false;
+#endif
 }
-HttpDownloader::DownloadError HttpDownloader::downloadToFile(const std::string& url,
-                                                             const std::string& destPath,
-                                                             ProgressCallback progress) {
+
+HttpDownloader::DownloadError HttpDownloader::downloadToFile(const std::string& url, const std::string& destPath,
+                                                             ProgressCallback progress, const std::string& username,
+                                                             const std::string& password) {
+#ifdef _WIN32
+  auto& storage = HalStorage::getInstance();
+  if (storage.exists(destPath.c_str())) {
+    storage.remove(destPath.c_str());
+  }
+
+  FsFile file = storage.open(destPath.c_str(), O_CREAT | O_TRUNC | O_WRONLY);
+  if (!file) {
+    return FILE_ERROR;
+  }
+
+  const bool ok = downloadWithWinHttp(url, username, password,
+                                      [&file, &progress](const uint8_t* data, size_t size, size_t downloaded,
+                                                         size_t total) {
+                                        if (file.write(data, size) != size) {
+                                          return false;
+                                        }
+                                        if (progress) progress(downloaded, total);
+                                        return true;
+                                      });
+  file.close();
+  if (!ok) {
+    storage.remove(destPath.c_str());
+    return HTTP_ERROR;
+  }
+  return OK;
+#else
   (void)url;
   (void)destPath;
   (void)progress;
-  return HttpDownloader::HTTP_ERROR;
+  (void)username;
+  (void)password;
+  return HTTP_ERROR;
+#endif
 }

--- a/sim/src/main_sim.cpp
+++ b/sim/src/main_sim.cpp
@@ -7,13 +7,27 @@
 #include <HardwareSerial.h>
 #include <SDCardManager.h>
 #include <SdFat.h>
+#include <activities/Activity.h>
+#include <activities/ActivityManager.h>
+#include <activities/util/KeyboardEntryActivity.h>
+#include <util/ScreenDebugState.h>
+#include <sim_gpio_control.h>
 #include "sim_display.h"
 
 #include <atomic>
 #include <cctype>
 #include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <optional>
+#include <queue>
+#include <sstream>
 #include <string>
-#include <unistd.h>
+#include <thread>
+#include <vector>
 
 // Crosspoint app entry points (from main.cpp)
 extern void setup();
@@ -22,6 +36,82 @@ extern void loop();
 namespace {
 constexpr int kLibraryThumbHeight = 100;
 
+struct SimCliOptions {
+  std::string inputScriptPath;
+  std::string screenshotPath;
+  long autoShotDelayMs = -1;
+  long exitAfterMs = -1;
+  std::string stateJsonPath;
+  long stateJsonIntervalMs = 100;
+  std::string waitForActivity;
+  long waitTimeoutMs = -1;
+  bool controlStdio = false;
+  bool resetSession = false;
+  long delayCapMs = -1;
+};
+
+struct ControlCommand {
+  enum class Type {
+    GetState,
+    GetScreen,
+    TypeText,
+    WaitMs,
+    Press,
+    Release,
+    ReleaseAll,
+    Hold,
+    Tap,
+    GoBack,
+    Screenshot,
+    WaitActivity,
+    WaitHeader,
+    WaitBody,
+    WaitListItem,
+    WaitMenuItem,
+    WaitSelectedListItem,
+    WaitSelectedMenuItem,
+    WaitPopup,
+    ActivateVisibleListItem,
+    ActivateVisibleMenuItem,
+    Quit,
+    Invalid
+  };
+  Type type = Type::Invalid;
+  uint8_t button = 0xFF;
+  unsigned long durationMs = 150;
+  unsigned long timeoutMs = 30000;
+  std::string arg;
+};
+
+struct PendingControlWait {
+  enum class Kind { Activity, Header, Body, ListItem, MenuItem, SelectedListItem, SelectedMenuItem, Popup, Delay };
+  Kind kind = Kind::Activity;
+  std::string value;
+  unsigned long startedAtMs = 0;
+  unsigned long timeoutMs = 30000;
+  unsigned long lastProgressAtMs = 0;
+};
+
+struct PendingControlAction {
+  enum class Kind { ActivateVisibleListItem, ActivateVisibleMenuItem, GoBack, HoldButton };
+  Kind kind = Kind::ActivateVisibleListItem;
+  std::string value;
+  uint8_t button = 0xFF;
+  std::string sourceActivityName;
+  std::string sourceHeaderTitle;
+  std::string sourceBodyPrimaryText;
+  std::string sourceBodySecondaryText;
+  std::string sourcePopupMessage;
+  std::string sourceSelectedLabel;
+  std::string sourceSelectedTitle;
+  int sourceMenuItemCount = 0;
+  int sourceListItemCount = 0;
+  unsigned long startedAtMs = 0;
+  unsigned long timeoutMs = 10000;
+  unsigned long nextStepAtMs = 0;
+  bool confirmQueued = false;
+};
+
 bool endsWithEpub(const std::string& name) {
   if (name.size() < 5) return false;
   std::string ext = name.substr(name.size() - 5);
@@ -29,7 +119,1159 @@ bool endsWithEpub(const std::string& name) {
   return ext == ".epub";
 }
 
+std::filesystem::path resolveSimSdcardRoot() {
+  namespace fs = std::filesystem;
+  std::error_code ec;
+  fs::path resolved = fs::absolute("./sdcard", ec);
+  if (!ec && fs::exists(resolved, ec)) {
+    return resolved.lexically_normal();
+  }
+
+  ec.clear();
+  resolved = fs::absolute("../sdcard", ec);
+  if (!ec && fs::exists(resolved, ec)) {
+    return resolved.lexically_normal();
+  }
+
+  return fs::absolute("./sdcard").lexically_normal();
+}
+
+void resetEmulatorSessionState() {
+  namespace fs = std::filesystem;
+  const fs::path sdRoot = resolveSimSdcardRoot();
+  std::error_code ec;
+  fs::create_directories(sdRoot, ec);
+
+  const fs::path crosspointRoot = sdRoot / ".crosspoint";
+  const fs::path recentJsonPath = crosspointRoot / "recent.json";
+  const fs::path stateJsonPath = crosspointRoot / "state.json";
+
+  const fs::path filesToRemove[] = {recentJsonPath, stateJsonPath};
+  for (const auto& filePath : filesToRemove) {
+    ec.clear();
+    fs::remove(filePath, ec);
+  }
+
+  if (fs::exists(crosspointRoot, ec)) {
+    for (fs::directory_iterator it(crosspointRoot, ec), end; it != end && !ec; it.increment(ec)) {
+      const fs::path entryPath = it->path();
+      const std::string name = entryPath.filename().string();
+      if (!it->is_directory(ec)) continue;
+      if (name == "plugins") continue;
+      std::error_code removeEc;
+      fs::remove_all(entryPath, removeEc);
+    }
+  }
+}
+
 std::atomic<bool> g_prewarmDone{false};
+bool g_autoScreenshotDone = false;
+bool g_autoExitDone = false;
+bool g_waitSatisfied = false;
+bool g_controlReadyEmitted = false;
+std::string g_lastStateJson;
+unsigned long g_lastStateWriteMs = 0;
+SimCliOptions g_cliOptions;
+std::mutex g_controlMutex;
+std::queue<ControlCommand> g_controlCommands;
+std::optional<PendingControlWait> g_pendingControlWait;
+std::optional<PendingControlAction> g_pendingControlAction;
+std::thread g_controlReaderThread;
+std::mutex g_stdoutMutex;
+
+void setEnvVar(const char* key, const std::string& value) {
+#ifdef _MSC_VER
+  _putenv_s(key, value.c_str());
+#else
+  setenv(key, value.c_str(), 1);
+#endif
+}
+
+std::string jsonEscape(const std::string& input) {
+  std::string out;
+  out.reserve(input.size() + 16);
+  for (char ch : input) {
+    switch (ch) {
+      case '\\': out += "\\\\"; break;
+      case '"': out += "\\\""; break;
+      case '\n': out += "\\n"; break;
+      case '\r': out += "\\r"; break;
+      case '\t': out += "\\t"; break;
+      default:
+        if (static_cast<unsigned char>(ch) < 0x20) {
+          char buf[7];
+          std::snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned char>(ch));
+          out += buf;
+        } else {
+          out.push_back(ch);
+        }
+        break;
+    }
+  }
+  return out;
+}
+
+std::string toUpperAscii(std::string value) {
+  for (char& ch : value) ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+  return value;
+}
+
+std::string buildCompactStateJson();
+void emitControlJson(const std::string& payload);
+
+bool tryParseUnsignedLong(const std::string& raw, unsigned long& out) {
+  if (raw.empty()) return false;
+  char* end = nullptr;
+  const auto parsed = std::strtoul(raw.c_str(), &end, 10);
+  if (end == raw.c_str() || *end != '\0') return false;
+  out = parsed;
+  return true;
+}
+
+std::string trimAscii(const std::string& value) {
+  size_t start = 0;
+  while (start < value.size() && std::isspace(static_cast<unsigned char>(value[start]))) ++start;
+  size_t end = value.size();
+  while (end > start && std::isspace(static_cast<unsigned char>(value[end - 1]))) --end;
+  return value.substr(start, end - start);
+}
+
+bool parseWaitTextAndTimeout(std::istringstream& iss, const std::string& commandName, std::string& text,
+                             unsigned long& timeoutMs, std::string& error) {
+  std::string remainder;
+  std::getline(iss, remainder);
+  remainder = trimAscii(remainder);
+  if (remainder.empty()) {
+    error = commandName + " requires text to match";
+    return false;
+  }
+
+  const auto lastSpace = remainder.find_last_of(" \t");
+  if (lastSpace != std::string::npos) {
+    const auto maybeTimeout = trimAscii(remainder.substr(lastSpace + 1));
+    unsigned long parsedTimeout = 0;
+    if (tryParseUnsignedLong(maybeTimeout, parsedTimeout)) {
+      const auto maybeText = trimAscii(remainder.substr(0, lastSpace));
+      if (!maybeText.empty()) {
+        text = maybeText;
+        timeoutMs = parsedTimeout;
+        return true;
+      }
+    }
+  }
+
+  text = remainder;
+  return true;
+}
+
+std::string screenSnapshotJson() {
+  const auto screen = SCREEN_DEBUG.getSnapshot();
+  std::ostringstream out;
+  out << "{";
+  out << "\"activityName\":\"" << jsonEscape(screen.activityName) << "\"";
+  out << ",\"headerTitle\":\"" << jsonEscape(screen.headerTitle) << "\"";
+  out << ",\"headerSubtitle\":\"" << jsonEscape(screen.headerSubtitle) << "\"";
+  out << ",\"subHeaderLabel\":\"" << jsonEscape(screen.subHeaderLabel) << "\"";
+  out << ",\"subHeaderRightLabel\":\"" << jsonEscape(screen.subHeaderRightLabel) << "\"";
+  out << ",\"bodyPrimaryText\":\"" << jsonEscape(screen.bodyPrimaryText) << "\"";
+  out << ",\"bodySecondaryText\":\"" << jsonEscape(screen.bodySecondaryText) << "\"";
+  out << ",\"bodyTertiaryText\":\"" << jsonEscape(screen.bodyTertiaryText) << "\"";
+  out << ",\"popupMessage\":\"" << jsonEscape(screen.popupMessage) << "\"";
+  out << ",\"diagnostics\":{";
+  out << "\"trackedSeriesLoaded\":" << (screen.diagnostics.trackedSeriesLoaded ? "true" : "false");
+  out << ",\"trackedSeriesCount\":" << screen.diagnostics.trackedSeriesCount;
+  out << ",\"totalJobCount\":" << screen.diagnostics.totalJobCount;
+  out << ",\"activeJobCount\":" << screen.diagnostics.activeJobCount;
+  out << ",\"coverCacheFileCount\":" << screen.diagnostics.coverCacheFileCount;
+  out << ",\"summary\":\"" << jsonEscape(screen.diagnostics.summary) << "\"}";
+  out << ",\"buttonHints\":{";
+  out << "\"btn1\":\"" << jsonEscape(screen.buttonHints.btn1) << "\"";
+  out << ",\"btn2\":\"" << jsonEscape(screen.buttonHints.btn2) << "\"";
+  out << ",\"btn3\":\"" << jsonEscape(screen.buttonHints.btn3) << "\"";
+  out << ",\"btn4\":\"" << jsonEscape(screen.buttonHints.btn4) << "\"}";
+  out << ",\"buttonMenu\":{";
+  out << "\"selectedIndex\":" << screen.buttonMenu.selectedIndex;
+  out << ",\"selectedLabel\":\"" << jsonEscape(screen.buttonMenu.selectedLabel) << "\"";
+  out << ",\"labels\":[";
+  for (size_t i = 0; i < screen.buttonMenu.labels.size(); ++i) {
+    if (i > 0) out << ",";
+    out << "\"" << jsonEscape(screen.buttonMenu.labels[i]) << "\"";
+  }
+  out << "]}";
+  out << ",\"list\":{";
+  out << "\"itemCount\":" << screen.list.itemCount;
+  out << ",\"selectedIndex\":" << screen.list.selectedIndex;
+  out << ",\"selectedVisibleIndex\":" << screen.list.selectedVisibleIndex;
+  out << ",\"selectedTitle\":\"" << jsonEscape(screen.list.selectedTitle) << "\"";
+  out << ",\"selectedSubtitle\":\"" << jsonEscape(screen.list.selectedSubtitle) << "\"";
+  out << ",\"selectedValue\":\"" << jsonEscape(screen.list.selectedValue) << "\"";
+  out << ",\"visibleItems\":[";
+  for (size_t i = 0; i < screen.list.visibleItems.size(); ++i) {
+    if (i > 0) out << ",";
+    out << "{";
+    out << "\"title\":\"" << jsonEscape(screen.list.visibleItems[i].title) << "\"";
+    out << ",\"subtitle\":\"" << jsonEscape(screen.list.visibleItems[i].subtitle) << "\"";
+    out << ",\"value\":\"" << jsonEscape(screen.list.visibleItems[i].value) << "\"";
+    out << "}";
+  }
+  out << "]}}";
+  return out.str();
+}
+
+const char* controlWaitKindName(PendingControlWait::Kind kind) {
+  switch (kind) {
+    case PendingControlWait::Kind::Activity: return "activity";
+    case PendingControlWait::Kind::Header: return "header";
+    case PendingControlWait::Kind::Body: return "body";
+    case PendingControlWait::Kind::ListItem: return "list_item";
+    case PendingControlWait::Kind::MenuItem: return "menu_item";
+    case PendingControlWait::Kind::SelectedListItem: return "selected_list_item";
+    case PendingControlWait::Kind::SelectedMenuItem: return "selected_menu_item";
+    case PendingControlWait::Kind::Popup: return "popup";
+    case PendingControlWait::Kind::Delay: return "delay";
+  }
+  return "unknown";
+}
+
+bool containsAsciiCaseInsensitive(const std::string& haystack, const std::string& needle) {
+  if (needle.empty()) return true;
+  const auto upperHaystack = toUpperAscii(haystack);
+  const auto upperNeedle = toUpperAscii(needle);
+  return upperHaystack.find(upperNeedle) != std::string::npos;
+}
+
+bool matchesListItemText(const ScreenDebugListItem& item, const std::string& value, std::string& matchedText) {
+  if (containsAsciiCaseInsensitive(item.title, value)) {
+    matchedText = item.title;
+    return true;
+  }
+  if (containsAsciiCaseInsensitive(item.subtitle, value)) {
+    matchedText = item.subtitle;
+    return true;
+  }
+  if (containsAsciiCaseInsensitive(item.value, value)) {
+    matchedText = item.value;
+    return true;
+  }
+  return false;
+}
+
+bool screenBodyMatches(const ScreenDebugSnapshot& screen, const std::string& value, std::string& matchedText);
+
+bool screenMatchesWait(const PendingControlWait& wait, std::string& matchedText) {
+  const auto screen = SCREEN_DEBUG.getSnapshot();
+
+  switch (wait.kind) {
+    case PendingControlWait::Kind::Activity:
+      if (activityManager.getCurrentActivityName() == wait.value) {
+        matchedText = activityManager.getCurrentActivityName();
+        return true;
+      }
+      return false;
+    case PendingControlWait::Kind::Header:
+      if (containsAsciiCaseInsensitive(screen.headerTitle, wait.value)) {
+        matchedText = screen.headerTitle;
+        return true;
+      }
+      if (containsAsciiCaseInsensitive(screen.headerSubtitle, wait.value)) {
+        matchedText = screen.headerSubtitle;
+        return true;
+      }
+      return false;
+    case PendingControlWait::Kind::Body: return screenBodyMatches(screen, wait.value, matchedText);
+    case PendingControlWait::Kind::ListItem:
+      for (const auto& item : screen.list.visibleItems) {
+        if (matchesListItemText(item, wait.value, matchedText)) return true;
+      }
+      return false;
+    case PendingControlWait::Kind::MenuItem:
+      for (const auto& label : screen.buttonMenu.labels) {
+        if (containsAsciiCaseInsensitive(label, wait.value)) {
+          matchedText = label;
+          return true;
+        }
+      }
+      return false;
+    case PendingControlWait::Kind::SelectedListItem: {
+      ScreenDebugListItem selectedItem{screen.list.selectedTitle, screen.list.selectedSubtitle, screen.list.selectedValue};
+      return matchesListItemText(selectedItem, wait.value, matchedText);
+    }
+    case PendingControlWait::Kind::SelectedMenuItem:
+      if (containsAsciiCaseInsensitive(screen.buttonMenu.selectedLabel, wait.value)) {
+        matchedText = screen.buttonMenu.selectedLabel;
+        return true;
+      }
+      return false;
+    case PendingControlWait::Kind::Popup:
+      if (containsAsciiCaseInsensitive(screen.popupMessage, wait.value)) {
+        matchedText = screen.popupMessage;
+        return true;
+      }
+      return false;
+    case PendingControlWait::Kind::Delay:
+      if (millis() >= wait.startedAtMs + wait.timeoutMs) {
+        matchedText = std::to_string(wait.timeoutMs) + "ms";
+        return true;
+      }
+      return false;
+  }
+  return false;
+}
+
+bool screenBodyMatches(const ScreenDebugSnapshot& screen, const std::string& value, std::string& matchedText) {
+  if (containsAsciiCaseInsensitive(screen.bodyPrimaryText, value)) {
+    matchedText = screen.bodyPrimaryText;
+    return true;
+  }
+  if (containsAsciiCaseInsensitive(screen.bodySecondaryText, value)) {
+    matchedText = screen.bodySecondaryText;
+    return true;
+  }
+  if (containsAsciiCaseInsensitive(screen.bodyTertiaryText, value)) {
+    matchedText = screen.bodyTertiaryText;
+    return true;
+  }
+  return false;
+}
+
+bool visibleListContains(const ScreenDebugSnapshot& screen, const std::string& value, int& targetVisibleIndex) {
+  targetVisibleIndex = -1;
+  std::string ignored;
+  for (size_t i = 0; i < screen.list.visibleItems.size(); ++i) {
+    if (matchesListItemText(screen.list.visibleItems[i], value, ignored)) {
+      targetVisibleIndex = static_cast<int>(i);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool visibleMenuContains(const ScreenDebugSnapshot& screen, const std::string& value, int& targetIndex) {
+  targetIndex = -1;
+  for (size_t i = 0; i < screen.buttonMenu.labels.size(); ++i) {
+    if (containsAsciiCaseInsensitive(screen.buttonMenu.labels[i], value)) {
+      targetIndex = static_cast<int>(i);
+      return true;
+    }
+  }
+  return false;
+}
+
+bool startPendingActivation(PendingControlAction::Kind kind, const std::string& value, std::string& message) {
+  const auto screen = SCREEN_DEBUG.getSnapshot();
+  int targetIndex = -1;
+  const bool found = kind == PendingControlAction::Kind::ActivateVisibleListItem
+                         ? visibleListContains(screen, value, targetIndex)
+                         : visibleMenuContains(screen, value, targetIndex);
+  if (!found) {
+    message = std::string(kind == PendingControlAction::Kind::ActivateVisibleListItem ? "Visible list item not found: "
+                                                                                       : "Visible menu item not found: ") +
+              value;
+    return false;
+  }
+
+  const unsigned long nowMs = millis();
+  g_pendingControlAction = PendingControlAction{kind,
+                                                value,
+                                                0xFF,
+                                                screen.activityName,
+                                                screen.headerTitle,
+                                                screen.bodyPrimaryText,
+                                                screen.bodySecondaryText,
+                                                screen.popupMessage,
+                                                screen.buttonMenu.selectedLabel,
+                                                screen.list.selectedTitle,
+                                                static_cast<int>(screen.buttonMenu.labels.size()),
+                                                screen.list.itemCount,
+                                                nowMs,
+                                                12000,
+                                                nowMs + 120,
+                                                false};
+  return true;
+}
+
+bool startPendingGoBack(unsigned long timeoutMs, std::string& message) {
+  const auto screen = SCREEN_DEBUG.getSnapshot();
+  const auto stackActivities = activityManager.getStackActivityNames();
+  if (stackActivities.empty() && activityManager.getCurrentActivityName() == "Home") {
+    message = "Already at root screen";
+    return false;
+  }
+
+  const unsigned long nowMs = millis();
+  g_pendingControlAction = PendingControlAction{PendingControlAction::Kind::GoBack,
+                                                "",
+                                                0xFF,
+                                                screen.activityName,
+                                                screen.headerTitle,
+                                                screen.bodyPrimaryText,
+                                                screen.bodySecondaryText,
+                                                screen.popupMessage,
+                                                screen.buttonMenu.selectedLabel,
+                                                screen.list.selectedTitle,
+                                                static_cast<int>(screen.buttonMenu.labels.size()),
+                                                screen.list.itemCount,
+                                                nowMs,
+                                                timeoutMs == 0 ? 10000UL : timeoutMs,
+                                                nowMs + 120,
+                                                false};
+  return true;
+}
+
+bool isReadOnlyControlCommand(const ControlCommand::Type type) {
+  return type == ControlCommand::Type::GetState || type == ControlCommand::Type::GetScreen ||
+         type == ControlCommand::Type::Screenshot;
+}
+
+bool canBypassBarrier(const ControlCommand::Type type) {
+  return type == ControlCommand::Type::ReleaseAll || type == ControlCommand::Type::Quit ||
+         isReadOnlyControlCommand(type);
+}
+
+bool canRunBeforeControlReady(const ControlCommand::Type type) {
+  switch (type) {
+    case ControlCommand::Type::GetState:
+    case ControlCommand::Type::GetScreen:
+    case ControlCommand::Type::WaitMs:
+    case ControlCommand::Type::WaitActivity:
+    case ControlCommand::Type::WaitHeader:
+    case ControlCommand::Type::WaitBody:
+    case ControlCommand::Type::WaitListItem:
+    case ControlCommand::Type::WaitMenuItem:
+    case ControlCommand::Type::WaitSelectedListItem:
+    case ControlCommand::Type::WaitSelectedMenuItem:
+    case ControlCommand::Type::WaitPopup:
+    case ControlCommand::Type::ReleaseAll:
+    case ControlCommand::Type::Screenshot:
+    case ControlCommand::Type::Quit:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool controlChannelReady() {
+  if (!g_cliOptions.controlStdio) return false;
+  if (g_controlReadyEmitted) return true;
+  if (!activityManager.getPendingActivityName().empty()) return false;
+  if (activityManager.getPendingActionName() != "none") return false;
+
+  const auto screen = SCREEN_DEBUG.getSnapshot();
+  const bool hasInteractiveMenu = !screen.buttonMenu.labels.empty();
+  const bool hasInteractiveList = screen.list.itemCount > 0;
+  const bool hasVisibleActivity = !activityManager.getCurrentActivityName().empty();
+  return hasVisibleActivity && (hasInteractiveMenu || hasInteractiveList);
+}
+
+void maybeEmitControlReady() {
+  if (!g_cliOptions.controlStdio || g_controlReadyEmitted || !controlChannelReady()) return;
+  g_controlReadyEmitted = true;
+  emitControlJson(std::string("{\"ok\":true,\"event\":\"ready\",\"state\":") + buildCompactStateJson() + "}");
+}
+
+void printHelp() {
+  std::puts("Crosspoint Emulator CLI");
+  std::puts("  --input-script <path>");
+  std::puts("  --screenshot-path <path>");
+  std::puts("  --autoshot-delay-ms <ms>");
+  std::puts("  --exit-after-ms <ms>");
+  std::puts("  --state-json <path>");
+  std::puts("  --state-json-interval-ms <ms>");
+  std::puts("  --wait-for-activity <name>");
+  std::puts("  --wait-timeout-ms <ms>");
+  std::puts("  --reset-session");
+  std::puts("  --delay-cap-ms <ms>");
+  std::puts("  --control-stdio");
+  std::puts("  --help");
+}
+
+bool parseLongArg(const char* raw, long& out) {
+  if (!raw || !*raw) return false;
+  char* end = nullptr;
+  out = std::strtol(raw, &end, 10);
+  return end != raw && *end == '\0';
+}
+
+bool parseArgs(int argc, char** argv, SimCliOptions& options) {
+  for (int i = 1; i < argc; ++i) {
+    const std::string arg = argv[i];
+    auto requireValue = [&](const char* name) -> const char* {
+      if (i + 1 >= argc) {
+        std::fprintf(stderr, "Missing value for %s\n", name);
+        return nullptr;
+      }
+      return argv[++i];
+    };
+
+    if (arg == "--help" || arg == "-h") {
+      printHelp();
+      std::exit(0);
+    } else if (arg == "--input-script") {
+      const char* value = requireValue("--input-script");
+      if (!value) return false;
+      options.inputScriptPath = value;
+    } else if (arg == "--screenshot-path") {
+      const char* value = requireValue("--screenshot-path");
+      if (!value) return false;
+      options.screenshotPath = value;
+    } else if (arg == "--autoshot-delay-ms") {
+      const char* value = requireValue("--autoshot-delay-ms");
+      if (!value || !parseLongArg(value, options.autoShotDelayMs)) return false;
+    } else if (arg == "--exit-after-ms") {
+      const char* value = requireValue("--exit-after-ms");
+      if (!value || !parseLongArg(value, options.exitAfterMs)) return false;
+    } else if (arg == "--state-json") {
+      const char* value = requireValue("--state-json");
+      if (!value) return false;
+      options.stateJsonPath = value;
+    } else if (arg == "--state-json-interval-ms") {
+      const char* value = requireValue("--state-json-interval-ms");
+      if (!value || !parseLongArg(value, options.stateJsonIntervalMs)) return false;
+    } else if (arg == "--wait-for-activity") {
+      const char* value = requireValue("--wait-for-activity");
+      if (!value) return false;
+      options.waitForActivity = value;
+    } else if (arg == "--wait-timeout-ms") {
+      const char* value = requireValue("--wait-timeout-ms");
+      if (!value || !parseLongArg(value, options.waitTimeoutMs)) return false;
+    } else if (arg == "--reset-session") {
+      options.resetSession = true;
+    } else if (arg == "--delay-cap-ms") {
+      const char* value = requireValue("--delay-cap-ms");
+      if (!value || !parseLongArg(value, options.delayCapMs)) return false;
+    } else if (arg == "--control-stdio") {
+      options.controlStdio = true;
+    } else {
+      std::fprintf(stderr, "Unknown argument: %s\n", arg.c_str());
+      return false;
+    }
+  }
+  return true;
+}
+
+void normalizeCliPaths(SimCliOptions& options) {
+  namespace fs = std::filesystem;
+
+  auto normalizePath = [](std::string& path) {
+    if (path.empty()) return;
+    std::error_code ec;
+    fs::path resolved = fs::absolute(fs::path(path), ec);
+    if (!ec) {
+      path = resolved.lexically_normal().string();
+    }
+  };
+
+  normalizePath(options.inputScriptPath);
+  normalizePath(options.screenshotPath);
+  normalizePath(options.stateJsonPath);
+}
+
+void applyCliOptions(const SimCliOptions& options) {
+  if (!options.inputScriptPath.empty()) setEnvVar("SIM_INPUT_SCRIPT", options.inputScriptPath);
+  if (!options.screenshotPath.empty()) setEnvVar("SIM_SCREENSHOT_PATH", options.screenshotPath);
+  if (options.autoShotDelayMs >= 0) setEnvVar("SIM_AUTOSHOT_DELAY_MS", std::to_string(options.autoShotDelayMs));
+  if (options.exitAfterMs >= 0) setEnvVar("SIM_EXIT_AFTER_MS", std::to_string(options.exitAfterMs));
+  if (options.delayCapMs >= 0) setEnvVar("SIM_DELAY_CAP_MS", std::to_string(options.delayCapMs));
+}
+
+std::string buildStateJson() {
+  const auto screen = SCREEN_DEBUG.getSnapshot();
+  std::ostringstream out;
+  const auto stack = activityManager.getStackActivityNames();
+  out << "{\n";
+  out << "  \"millis\": " << millis() << ",\n";
+  out << "  \"currentActivity\": \"" << jsonEscape(activityManager.getCurrentActivityName()) << "\",\n";
+  out << "  \"pendingAction\": \"" << jsonEscape(activityManager.getPendingActionName()) << "\",\n";
+  out << "  \"pendingActivity\": \"" << jsonEscape(activityManager.getPendingActivityName()) << "\",\n";
+  out << "  \"stackActivities\": [";
+  for (size_t i = 0; i < stack.size(); ++i) {
+    if (i > 0) out << ", ";
+    out << "\"" << jsonEscape(stack[i]) << "\"";
+  }
+  out << "],\n";
+  out << "  \"prewarmDone\": " << (g_prewarmDone.load() ? "true" : "false") << ",\n";
+  out << "  \"autoScreenshotDone\": " << (g_autoScreenshotDone ? "true" : "false") << ",\n";
+  out << "  \"autoExitDone\": " << (g_autoExitDone ? "true" : "false") << ",\n";
+  out << "  \"waitSatisfied\": " << (g_waitSatisfied ? "true" : "false") << ",\n";
+  out << "  \"screen\": " << screenSnapshotJson() << ",\n";
+  out << "  \"diagnostics\": {\n";
+  out << "    \"trackedSeriesLoaded\": " << (screen.diagnostics.trackedSeriesLoaded ? "true" : "false") << ",\n";
+  out << "    \"trackedSeriesCount\": " << screen.diagnostics.trackedSeriesCount << ",\n";
+  out << "    \"totalJobCount\": " << screen.diagnostics.totalJobCount << ",\n";
+  out << "    \"activeJobCount\": " << screen.diagnostics.activeJobCount << ",\n";
+  out << "    \"coverCacheFileCount\": " << screen.diagnostics.coverCacheFileCount << ",\n";
+  out << "    \"summary\": \"" << jsonEscape(screen.diagnostics.summary) << "\"\n";
+  out << "  }\n";
+  out << "}\n";
+  return out.str();
+}
+
+std::string buildCompactStateJson() {
+  const auto stack = activityManager.getStackActivityNames();
+  std::ostringstream out;
+  out << "{\"millis\":" << millis();
+  out << ",\"currentActivity\":\"" << jsonEscape(activityManager.getCurrentActivityName()) << "\"";
+  out << ",\"pendingAction\":\"" << jsonEscape(activityManager.getPendingActionName()) << "\"";
+  out << ",\"pendingActivity\":\"" << jsonEscape(activityManager.getPendingActivityName()) << "\"";
+  out << ",\"stackActivities\":[";
+  for (size_t i = 0; i < stack.size(); ++i) {
+    if (i > 0) out << ",";
+    out << "\"" << jsonEscape(stack[i]) << "\"";
+  }
+  out << "]";
+  out << ",\"screen\":" << screenSnapshotJson();
+  out << "}";
+  return out.str();
+}
+
+void emitControlJson(const std::string& payload) {
+  std::lock_guard<std::mutex> lock(g_stdoutMutex);
+  std::printf("[SIMCTL] %s\n", payload.c_str());
+  std::fflush(stdout);
+}
+
+void emitControlError(const std::string& message) {
+  emitControlJson(std::string("{\"ok\":false,\"error\":\"") + jsonEscape(message) + "\"}");
+}
+
+std::optional<ControlCommand> parseControlCommandLine(const std::string& line) {
+  std::istringstream iss(line);
+  std::string name;
+  if (!(iss >> name)) return std::nullopt;
+
+  ControlCommand cmd;
+  std::string upperName = toUpperAscii(name);
+
+  if (upperName == "GET_STATE") {
+    cmd.type = ControlCommand::Type::GetState;
+    return cmd;
+  }
+  if (upperName == "GET_SCREEN") {
+    cmd.type = ControlCommand::Type::GetScreen;
+    return cmd;
+  }
+  if (upperName == "TYPE_TEXT") {
+    std::getline(iss, cmd.arg);
+    cmd.arg = trimAscii(cmd.arg);
+    cmd.type = cmd.arg.empty() ? ControlCommand::Type::Invalid : ControlCommand::Type::TypeText;
+    if (cmd.arg.empty()) cmd.arg = "TYPE_TEXT requires text";
+    return cmd;
+  }
+  if (upperName == "WAIT_MS") {
+    if (!(iss >> cmd.timeoutMs)) {
+      cmd.type = ControlCommand::Type::Invalid;
+      cmd.arg = "WAIT_MS requires a duration in milliseconds";
+      return cmd;
+    }
+    cmd.type = ControlCommand::Type::WaitMs;
+    return cmd;
+  }
+  if (upperName == "QUIT") {
+    cmd.type = ControlCommand::Type::Quit;
+    return cmd;
+  }
+  if (upperName == "GO_BACK") {
+    if (iss >> cmd.timeoutMs) {
+    }
+    cmd.type = ControlCommand::Type::GoBack;
+    return cmd;
+  }
+  if (upperName == "RELEASE_ALL") {
+    cmd.type = ControlCommand::Type::ReleaseAll;
+    return cmd;
+  }
+  if (upperName == "SCREENSHOT") {
+    std::getline(iss, cmd.arg);
+    if (!cmd.arg.empty() && cmd.arg[0] == ' ') cmd.arg.erase(cmd.arg.begin());
+    cmd.type = cmd.arg.empty() ? ControlCommand::Type::Invalid : ControlCommand::Type::Screenshot;
+    if (cmd.arg.empty()) cmd.arg = "SCREENSHOT requires a path";
+    return cmd;
+  }
+  if (upperName == "WAIT_ACTIVITY") {
+    if (!(iss >> cmd.arg)) {
+      cmd.type = ControlCommand::Type::Invalid;
+      cmd.arg = "WAIT_ACTIVITY requires an activity name";
+      return cmd;
+    }
+    if (iss >> cmd.timeoutMs) {
+    }
+    cmd.type = ControlCommand::Type::WaitActivity;
+    return cmd;
+  }
+  if (upperName == "WAIT_HEADER" || upperName == "WAIT_BODY" || upperName == "WAIT_LIST_ITEM" ||
+      upperName == "WAIT_MENU_ITEM" || upperName == "WAIT_SELECTED_LIST_ITEM" ||
+      upperName == "WAIT_SELECTED_MENU_ITEM" || upperName == "WAIT_POPUP") {
+    if (!parseWaitTextAndTimeout(iss, upperName, cmd.arg, cmd.timeoutMs, cmd.arg)) {
+      cmd.type = ControlCommand::Type::Invalid;
+      return cmd;
+    }
+    if (upperName == "WAIT_HEADER") {
+      cmd.type = ControlCommand::Type::WaitHeader;
+    } else if (upperName == "WAIT_BODY") {
+      cmd.type = ControlCommand::Type::WaitBody;
+    } else if (upperName == "WAIT_LIST_ITEM") {
+      cmd.type = ControlCommand::Type::WaitListItem;
+    } else if (upperName == "WAIT_MENU_ITEM") {
+      cmd.type = ControlCommand::Type::WaitMenuItem;
+    } else if (upperName == "WAIT_SELECTED_LIST_ITEM") {
+      cmd.type = ControlCommand::Type::WaitSelectedListItem;
+    } else if (upperName == "WAIT_SELECTED_MENU_ITEM") {
+      cmd.type = ControlCommand::Type::WaitSelectedMenuItem;
+    } else {
+      cmd.type = ControlCommand::Type::WaitPopup;
+    }
+    return cmd;
+  }
+  if (upperName == "ACTIVATE_VISIBLE_LIST_ITEM" || upperName == "ACTIVATE_VISIBLE_MENU_ITEM") {
+    std::getline(iss, cmd.arg);
+    cmd.arg = trimAscii(cmd.arg);
+    if (cmd.arg.empty()) {
+      cmd.type = ControlCommand::Type::Invalid;
+      cmd.arg = upperName + " requires text to match";
+      return cmd;
+    }
+    cmd.type = upperName == "ACTIVATE_VISIBLE_LIST_ITEM" ? ControlCommand::Type::ActivateVisibleListItem
+                                                          : ControlCommand::Type::ActivateVisibleMenuItem;
+    return cmd;
+  }
+  if (upperName == "PRESS" || upperName == "RELEASE" || upperName == "TAP" || upperName == "HOLD") {
+    std::string buttonName;
+    if (!(iss >> buttonName)) {
+      cmd.type = ControlCommand::Type::Invalid;
+      cmd.arg = upperName + " requires a button name";
+      return cmd;
+    }
+    if (!sim_gpio_try_parse_button(buttonName, cmd.button)) {
+      cmd.type = ControlCommand::Type::Invalid;
+      cmd.arg = "Unknown button: " + buttonName;
+      return cmd;
+    }
+    if ((upperName == "TAP" || upperName == "HOLD") && (iss >> cmd.durationMs)) {
+    }
+    cmd.type = upperName == "PRESS"   ? ControlCommand::Type::Press
+               : upperName == "RELEASE" ? ControlCommand::Type::Release
+               : upperName == "HOLD"    ? ControlCommand::Type::Hold
+                                        : ControlCommand::Type::Tap;
+    return cmd;
+  }
+
+  cmd.type = ControlCommand::Type::Invalid;
+  cmd.arg = "Unknown control command: " + name;
+  return cmd;
+}
+
+void startControlReader() {
+  g_controlReaderThread = std::thread([] {
+    std::string line;
+    while (std::getline(std::cin, line)) {
+      auto parsed = parseControlCommandLine(line);
+      if (!parsed.has_value()) continue;
+      std::lock_guard<std::mutex> lock(g_controlMutex);
+      g_controlCommands.push(*parsed);
+    }
+  });
+  g_controlReaderThread.detach();
+}
+
+void drainControlCommands() {
+  while (true) {
+    ControlCommand cmd;
+    {
+      std::lock_guard<std::mutex> lock(g_controlMutex);
+      if (g_controlCommands.empty()) break;
+      cmd = g_controlCommands.front();
+      if (!g_controlReadyEmitted && !canRunBeforeControlReady(cmd.type)) {
+        break;
+      }
+      const bool blockedByBarrier = g_pendingControlWait.has_value() || g_pendingControlAction.has_value();
+      if (blockedByBarrier && !canBypassBarrier(cmd.type)) {
+        break;
+      }
+      g_controlCommands.pop();
+    }
+
+    switch (cmd.type) {
+      case ControlCommand::Type::GetState:
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"state\",\"state\":") + buildCompactStateJson() + "}");
+        break;
+      case ControlCommand::Type::GetScreen:
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"screen\",\"screen\":") + screenSnapshotJson() + "}");
+        break;
+      case ControlCommand::Type::TypeText:
+        if (activityManager.injectAutomationText(cmd.arg)) {
+          emitControlJson(std::string("{\"ok\":true,\"event\":\"text_typed\",\"text\":\"") + jsonEscape(cmd.arg) + "\"}");
+        } else {
+          emitControlError("Current activity does not accept automation text input");
+        }
+        break;
+      case ControlCommand::Type::WaitMs:
+        g_pendingControlWait = PendingControlWait{PendingControlWait::Kind::Delay, std::to_string(cmd.timeoutMs) + "ms",
+                                                  millis(), cmd.timeoutMs, 0};
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"wait_started\",\"waitType\":\"delay\",\"value\":\"") +
+                        std::to_string(cmd.timeoutMs) + "ms\",\"timeoutMs\":" + std::to_string(cmd.timeoutMs) + "}");
+        return;
+      case ControlCommand::Type::Press:
+        sim_gpio_press_button(cmd.button);
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"pressed\",\"button\":\"") +
+                        jsonEscape(sim_gpio_button_name(cmd.button)) + "\"}");
+        break;
+      case ControlCommand::Type::Release:
+        sim_gpio_release_button(cmd.button);
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"released\",\"button\":\"") +
+                        jsonEscape(sim_gpio_button_name(cmd.button)) + "\"}");
+        break;
+      case ControlCommand::Type::ReleaseAll:
+        sim_gpio_release_all_buttons();
+        if (g_pendingControlAction.has_value() && g_pendingControlAction->kind == PendingControlAction::Kind::HoldButton) {
+          g_pendingControlAction.reset();
+        }
+        emitControlJson("{\"ok\":true,\"event\":\"released_all\"}");
+        break;
+      case ControlCommand::Type::Hold: {
+        const unsigned long nowMs = millis();
+        g_pendingControlAction = PendingControlAction{PendingControlAction::Kind::HoldButton,
+                                                      "",
+                                                      cmd.button,
+                                                      activityManager.getCurrentActivityName(),
+                                                      "",
+                                                      "",
+                                                      "",
+                                                      "",
+                                                      "",
+                                                      "",
+                                                      0,
+                                                      0,
+                                                      nowMs,
+                                                      cmd.durationMs == 0 ? 150UL : cmd.durationMs,
+                                                      nowMs,
+                                                      false};
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"action_started\",\"action\":\"hold\",\"button\":\"") +
+                        jsonEscape(sim_gpio_button_name(cmd.button)) + "\",\"durationMs\":" +
+                        std::to_string(cmd.durationMs == 0 ? 150UL : cmd.durationMs) + "}");
+        return;
+      }
+      case ControlCommand::Type::Tap:
+        sim_gpio_tap_button(cmd.button, cmd.durationMs);
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"tapped\",\"button\":\"") +
+                        jsonEscape(sim_gpio_button_name(cmd.button)) + "\",\"durationMs\":" +
+                        std::to_string(cmd.durationMs) + "}");
+        break;
+      case ControlCommand::Type::GoBack: {
+        std::string message;
+        if (startPendingGoBack(cmd.timeoutMs, message)) {
+          emitControlJson(std::string("{\"ok\":true,\"event\":\"action_started\",\"action\":\"go_back\",\"timeoutMs\":") +
+                          std::to_string(cmd.timeoutMs == 0 ? 10000UL : cmd.timeoutMs) + "}");
+          return;
+        }
+        emitControlError(message);
+        break;
+      }
+      case ControlCommand::Type::Screenshot:
+        if (sim_display_save_screenshot(cmd.arg.c_str())) {
+          emitControlJson(std::string("{\"ok\":true,\"event\":\"screenshot\",\"path\":\"") + jsonEscape(cmd.arg) + "\"}");
+        } else {
+          emitControlError("Failed to save screenshot");
+        }
+        break;
+      case ControlCommand::Type::WaitActivity:
+        g_pendingControlWait = PendingControlWait{PendingControlWait::Kind::Activity, cmd.arg, millis(), cmd.timeoutMs, 0};
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"wait_started\",\"waitType\":\"activity\",\"value\":\"") +
+                        jsonEscape(cmd.arg) + "\",\"timeoutMs\":" + std::to_string(cmd.timeoutMs) + "}");
+        return;
+      case ControlCommand::Type::WaitHeader:
+        g_pendingControlWait = PendingControlWait{PendingControlWait::Kind::Header, cmd.arg, millis(), cmd.timeoutMs, 0};
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"wait_started\",\"waitType\":\"header\",\"value\":\"") +
+                        jsonEscape(cmd.arg) + "\",\"timeoutMs\":" + std::to_string(cmd.timeoutMs) + "}");
+        return;
+      case ControlCommand::Type::WaitBody:
+        g_pendingControlWait = PendingControlWait{PendingControlWait::Kind::Body, cmd.arg, millis(), cmd.timeoutMs, 0};
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"wait_started\",\"waitType\":\"body\",\"value\":\"") +
+                        jsonEscape(cmd.arg) + "\",\"timeoutMs\":" + std::to_string(cmd.timeoutMs) + "}");
+        return;
+      case ControlCommand::Type::WaitListItem:
+        g_pendingControlWait = PendingControlWait{PendingControlWait::Kind::ListItem, cmd.arg, millis(), cmd.timeoutMs, 0};
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"wait_started\",\"waitType\":\"list_item\",\"value\":\"") +
+                        jsonEscape(cmd.arg) + "\",\"timeoutMs\":" + std::to_string(cmd.timeoutMs) + "}");
+        return;
+      case ControlCommand::Type::WaitMenuItem:
+        g_pendingControlWait = PendingControlWait{PendingControlWait::Kind::MenuItem, cmd.arg, millis(), cmd.timeoutMs, 0};
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"wait_started\",\"waitType\":\"menu_item\",\"value\":\"") +
+                        jsonEscape(cmd.arg) + "\",\"timeoutMs\":" + std::to_string(cmd.timeoutMs) + "}");
+        return;
+      case ControlCommand::Type::WaitSelectedListItem:
+        g_pendingControlWait =
+            PendingControlWait{PendingControlWait::Kind::SelectedListItem, cmd.arg, millis(), cmd.timeoutMs, 0};
+        emitControlJson(std::string(
+                            "{\"ok\":true,\"event\":\"wait_started\",\"waitType\":\"selected_list_item\",\"value\":\"") +
+                        jsonEscape(cmd.arg) + "\",\"timeoutMs\":" + std::to_string(cmd.timeoutMs) + "}");
+        return;
+      case ControlCommand::Type::WaitSelectedMenuItem:
+        g_pendingControlWait =
+            PendingControlWait{PendingControlWait::Kind::SelectedMenuItem, cmd.arg, millis(), cmd.timeoutMs, 0};
+        emitControlJson(std::string(
+                            "{\"ok\":true,\"event\":\"wait_started\",\"waitType\":\"selected_menu_item\",\"value\":\"") +
+                        jsonEscape(cmd.arg) + "\",\"timeoutMs\":" + std::to_string(cmd.timeoutMs) + "}");
+        return;
+      case ControlCommand::Type::WaitPopup:
+        g_pendingControlWait = PendingControlWait{PendingControlWait::Kind::Popup, cmd.arg, millis(), cmd.timeoutMs, 0};
+        emitControlJson(std::string("{\"ok\":true,\"event\":\"wait_started\",\"waitType\":\"popup\",\"value\":\"") +
+                        jsonEscape(cmd.arg) + "\",\"timeoutMs\":" + std::to_string(cmd.timeoutMs) + "}");
+        return;
+      case ControlCommand::Type::ActivateVisibleListItem: {
+        std::string message;
+        if (startPendingActivation(PendingControlAction::Kind::ActivateVisibleListItem, cmd.arg, message)) {
+          emitControlJson(std::string("{\"ok\":true,\"event\":\"action_started\",\"action\":\"activate_visible_list_item\",\"value\":\"") +
+                          jsonEscape(cmd.arg) + "\"}");
+          return;
+        } else {
+          emitControlError(message);
+        }
+        break;
+      }
+      case ControlCommand::Type::ActivateVisibleMenuItem: {
+        std::string message;
+        if (startPendingActivation(PendingControlAction::Kind::ActivateVisibleMenuItem, cmd.arg, message)) {
+          emitControlJson(std::string("{\"ok\":true,\"event\":\"action_started\",\"action\":\"activate_visible_menu_item\",\"value\":\"") +
+                          jsonEscape(cmd.arg) + "\"}");
+          return;
+        } else {
+          emitControlError(message);
+        }
+        break;
+      }
+      case ControlCommand::Type::Quit:
+        emitControlJson("{\"ok\":true,\"event\":\"quitting\"}");
+        std::exit(0);
+      case ControlCommand::Type::Invalid:
+        emitControlError(cmd.arg);
+        break;
+    }
+  }
+}
+
+void updateControlWait() {
+  if (!g_pendingControlWait.has_value()) return;
+  const auto nowMs = millis();
+  auto& wait = *g_pendingControlWait;
+  std::string matchedText;
+  if (screenMatchesWait(wait, matchedText)) {
+    emitControlJson(std::string("{\"ok\":true,\"event\":\"wait_satisfied\",\"waitType\":\"") +
+                    controlWaitKindName(wait.kind) + "\",\"value\":\"" + jsonEscape(wait.value) +
+                    "\",\"matched\":\"" + jsonEscape(matchedText) + "\",\"state\":" + buildCompactStateJson() + "}");
+    g_pendingControlWait.reset();
+    return;
+  }
+  if (nowMs >= wait.lastProgressAtMs + 1000) {
+    wait.lastProgressAtMs = nowMs;
+    emitControlJson(std::string("{\"ok\":true,\"event\":\"wait_progress\",\"waitType\":\"") +
+                    controlWaitKindName(wait.kind) + "\",\"value\":\"" + jsonEscape(wait.value) +
+                    "\",\"elapsedMs\":" + std::to_string(nowMs - wait.startedAtMs) + ",\"timeoutMs\":" +
+                    std::to_string(wait.timeoutMs) + ",\"state\":" + buildCompactStateJson() + "}");
+  }
+  if (wait.timeoutMs > 0 && nowMs > wait.startedAtMs + wait.timeoutMs) {
+    emitControlJson(std::string("{\"ok\":false,\"event\":\"wait_timeout\",\"waitType\":\"") +
+                    controlWaitKindName(wait.kind) + "\",\"value\":\"" + jsonEscape(wait.value) +
+                    "\",\"state\":" + buildCompactStateJson() + "}");
+    g_pendingControlWait.reset();
+  }
+}
+
+const char* controlActionKindName(PendingControlAction::Kind kind) {
+  switch (kind) {
+    case PendingControlAction::Kind::ActivateVisibleListItem: return "activate_visible_list_item";
+    case PendingControlAction::Kind::ActivateVisibleMenuItem: return "activate_visible_menu_item";
+    case PendingControlAction::Kind::GoBack: return "go_back";
+    case PendingControlAction::Kind::HoldButton: return "hold";
+  }
+  return "unknown";
+}
+
+void finishControlActionSuccess(const PendingControlAction& action, const std::string& matched) {
+  emitControlJson(std::string("{\"ok\":true,\"event\":\"action_completed\",\"action\":\"") +
+                  controlActionKindName(action.kind) + "\",\"value\":\"" + jsonEscape(action.value) +
+                  "\",\"matched\":\"" + jsonEscape(matched) + "\",\"state\":" + buildCompactStateJson() + "}");
+  g_pendingControlAction.reset();
+}
+
+void finishControlActionError(const PendingControlAction& action, const std::string& error) {
+  emitControlJson(std::string("{\"ok\":false,\"event\":\"action_failed\",\"action\":\"") +
+                  controlActionKindName(action.kind) + "\",\"value\":\"" + jsonEscape(action.value) +
+                  "\",\"error\":\"" + jsonEscape(error) + "\",\"state\":" + buildCompactStateJson() + "}");
+  g_pendingControlAction.reset();
+}
+
+bool hasSameScreenActionCompleted(const PendingControlAction& action, const ScreenDebugSnapshot& screen) {
+  const bool menuStateChanged = screen.buttonMenu.selectedLabel != action.sourceSelectedLabel ||
+                                static_cast<int>(screen.buttonMenu.labels.size()) != action.sourceMenuItemCount;
+  const bool listStateChanged =
+      screen.list.selectedTitle != action.sourceSelectedTitle || screen.list.itemCount != action.sourceListItemCount;
+  const bool bodyChanged = screen.bodyPrimaryText != action.sourceBodyPrimaryText ||
+                           screen.bodySecondaryText != action.sourceBodySecondaryText;
+  const bool popupChanged = screen.popupMessage != action.sourcePopupMessage;
+  return menuStateChanged || listStateChanged || bodyChanged || popupChanged;
+}
+
+void updateControlAction() {
+  if (!g_pendingControlAction.has_value()) return;
+
+  const unsigned long nowMs = millis();
+  auto& action = *g_pendingControlAction;
+  if (action.kind == PendingControlAction::Kind::HoldButton) {
+    if (!action.confirmQueued) {
+      sim_gpio_press_button(action.button);
+      action.confirmQueued = true;
+      action.nextStepAtMs = nowMs + action.timeoutMs;
+      return;
+    }
+
+    if (nowMs < action.nextStepAtMs) {
+      return;
+    }
+
+    sim_gpio_release_button(action.button);
+    finishControlActionSuccess(action, sim_gpio_button_name(action.button));
+    return;
+  }
+
+  if (action.timeoutMs > 0 && nowMs > action.startedAtMs + action.timeoutMs) {
+    const auto screen = SCREEN_DEBUG.getSnapshot();
+    std::string message =
+        action.kind == PendingControlAction::Kind::GoBack
+            ? "Timed out waiting for back navigation from " +
+                  (action.sourceHeaderTitle.empty() ? action.sourceActivityName : action.sourceHeaderTitle)
+            : "Timed out while waiting for activation to complete";
+    if (!screen.headerTitle.empty() || !screen.activityName.empty()) {
+      message += " (still on " + (screen.headerTitle.empty() ? screen.activityName : screen.headerTitle) + ")";
+    }
+    finishControlActionError(action, message);
+    return;
+  }
+  if (nowMs < action.nextStepAtMs) {
+    return;
+  }
+
+  const auto screen = SCREEN_DEBUG.getSnapshot();
+  if (action.kind == PendingControlAction::Kind::GoBack) {
+    const bool transitioned =
+        screen.activityName != action.sourceActivityName || screen.headerTitle != action.sourceHeaderTitle;
+    if (transitioned && activityManager.getPendingActivityName().empty() && activityManager.getPendingActionName() == "none") {
+      finishControlActionSuccess(action, screen.headerTitle.empty() ? screen.activityName : screen.headerTitle);
+      return;
+    }
+
+    sim_gpio_tap_button(HalGPIO::BTN_BACK, 180);
+    action.nextStepAtMs = nowMs + 420;
+    return;
+  }
+
+  if (action.kind == PendingControlAction::Kind::ActivateVisibleListItem) {
+    if (action.confirmQueued) {
+      const bool transitioned =
+          screen.activityName != action.sourceActivityName || screen.headerTitle != action.sourceHeaderTitle;
+      const bool sameScreenActionCompleted = hasSameScreenActionCompleted(action, screen);
+      if ((transitioned || sameScreenActionCompleted) && activityManager.getPendingActivityName().empty() &&
+          activityManager.getPendingActionName() == "none") {
+        finishControlActionSuccess(action, screen.headerTitle.empty() ? screen.activityName : screen.headerTitle);
+      } else {
+        action.nextStepAtMs = nowMs + 100;
+      }
+      return;
+    }
+
+    int targetVisibleIndex = -1;
+    if (!visibleListContains(screen, action.value, targetVisibleIndex)) {
+      finishControlActionError(action, "Visible list item disappeared before activation");
+      return;
+    }
+
+    const int currentVisibleIndex = screen.list.selectedVisibleIndex;
+    if (currentVisibleIndex == targetVisibleIndex) {
+      sim_gpio_tap_button(HalGPIO::BTN_CONFIRM, 180);
+      action.confirmQueued = true;
+      action.nextStepAtMs = nowMs + 450;
+      return;
+    }
+
+    const bool selectionMissing = currentVisibleIndex < 0;
+    const uint8_t navButton =
+        selectionMissing || targetVisibleIndex > currentVisibleIndex ? HalGPIO::BTN_DOWN : HalGPIO::BTN_UP;
+    sim_gpio_tap_button(navButton, 160);
+    action.nextStepAtMs = nowMs + 320;
+    return;
+  }
+
+  if (action.confirmQueued) {
+    const bool transitioned =
+        screen.activityName != action.sourceActivityName || screen.headerTitle != action.sourceHeaderTitle;
+    const bool sameScreenActionCompleted = hasSameScreenActionCompleted(action, screen);
+    if ((transitioned || sameScreenActionCompleted) && activityManager.getPendingActivityName().empty() &&
+        activityManager.getPendingActionName() == "none") {
+      finishControlActionSuccess(action, screen.headerTitle.empty() ? screen.activityName : screen.headerTitle);
+    } else {
+      action.nextStepAtMs = nowMs + 100;
+    }
+    return;
+  }
+
+  int targetIndex = -1;
+  if (!visibleMenuContains(screen, action.value, targetIndex)) {
+    finishControlActionError(action, "Visible menu item disappeared before activation");
+    return;
+  }
+
+  const int currentIndex = screen.buttonMenu.selectedIndex;
+  if (currentIndex == targetIndex) {
+    sim_gpio_tap_button(HalGPIO::BTN_CONFIRM, 180);
+    action.confirmQueued = true;
+    action.nextStepAtMs = nowMs + 450;
+    return;
+  }
+
+  const bool selectionMissing = currentIndex < 0;
+  const uint8_t navButton = selectionMissing || targetIndex > currentIndex ? HalGPIO::BTN_DOWN : HalGPIO::BTN_UP;
+  sim_gpio_tap_button(navButton, 160);
+  action.nextStepAtMs = nowMs + 320;
+}
+
+void maybeWriteStateJson(bool force = false) {
+  if (g_cliOptions.stateJsonPath.empty()) return;
+
+  const unsigned long nowMs = millis();
+  if (!force && g_cliOptions.stateJsonIntervalMs > 0 &&
+      nowMs < g_lastStateWriteMs + static_cast<unsigned long>(g_cliOptions.stateJsonIntervalMs)) {
+    return;
+  }
+
+  const std::string stateJson = buildStateJson();
+  if (!force && stateJson == g_lastStateJson) return;
+
+  std::ofstream out(g_cliOptions.stateJsonPath, std::ios::binary | std::ios::trunc);
+  if (!out) {
+    std::fprintf(stderr, "[SIM] Failed to write state json: %s\n", g_cliOptions.stateJsonPath.c_str());
+    return;
+  }
+  out << stateJson;
+  g_lastStateJson = stateJson;
+  g_lastStateWriteMs = nowMs;
+}
+
+void maybeSatisfyWaitCondition() {
+  if (g_waitSatisfied || g_cliOptions.waitForActivity.empty()) return;
+  if (activityManager.getCurrentActivityName() != g_cliOptions.waitForActivity) return;
+
+  g_waitSatisfied = true;
+  std::printf("[%lu] [SIM] Wait condition satisfied: activity=%s\n", millis(), g_cliOptions.waitForActivity.c_str());
+  maybeWriteStateJson(true);
+}
+
+void maybeFailWaitTimeout() {
+  if (g_waitSatisfied || g_cliOptions.waitForActivity.empty() || g_cliOptions.waitTimeoutMs < 0) return;
+  if (millis() < static_cast<unsigned long>(g_cliOptions.waitTimeoutMs)) return;
+
+  std::fprintf(stderr, "[SIM] Timed out waiting for activity: %s\n", g_cliOptions.waitForActivity.c_str());
+  maybeWriteStateJson(true);
+  std::exit(2);
+}
 
 // Prewarm one EPUB per main-loop iteration so UI gets control between thumbnails
 // (matches device: single core, yields in image generation).
@@ -42,7 +1284,7 @@ void prewarmStep() {
   if (!g_prewarmRootOpen) {
     g_prewarmRoot = SdMan.open("/", O_RDONLY);
     if (!g_prewarmRoot || !g_prewarmRoot.isDirectory()) {
-      Serial.printf("[%lu] [SIM] Could not open SD root for thumb prewarm\n", millis());
+      std::printf("[%lu] [SIM] Could not open SD root for thumb prewarm\n", millis());
       g_prewarmDone.store(true);
       return;
     }
@@ -55,7 +1297,7 @@ void prewarmStep() {
     g_prewarmRoot.close();
     g_prewarmRootOpen = false;
     g_prewarmDone.store(true);
-    Serial.printf("[%lu] [SIM] Thumb prewarm complete\n", millis());
+    std::printf("[%lu] [SIM] Thumb prewarm complete\n", millis());
     return;
   }
   if (file.isDirectory()) {
@@ -77,24 +1319,62 @@ void prewarmStep() {
   const std::string path = "/" + filename;
   Epub epub(path, "/.crosspoint");
   if (!epub.load(true, true)) {
-    Serial.printf("[%lu] [SIM] Failed to load EPUB for thumb prewarm: %s\n", millis(), path.c_str());
+    std::printf("[%lu] [SIM] Failed to load EPUB for thumb prewarm: %s\n", millis(), path.c_str());
     return;
   }
   if (!epub.generateThumbBmp(kLibraryThumbHeight)) {
-    Serial.printf("[%lu] [SIM] Failed to prewarm thumb: %s\n", millis(), path.c_str());
+    std::printf("[%lu] [SIM] Failed to prewarm thumb: %s\n", millis(), path.c_str());
   } else {
-    Serial.printf("[%lu] [SIM] Prewarmed thumb: %s\n", millis(), path.c_str());
+    std::printf("[%lu] [SIM] Prewarmed thumb: %s\n", millis(), path.c_str());
   }
+}
+
+void maybeAutoScreenshot() {
+  if (g_autoScreenshotDone) return;
+  const char* path = std::getenv("SIM_SCREENSHOT_PATH");
+  const char* delayMsStr = std::getenv("SIM_AUTOSHOT_DELAY_MS");
+  if (!path || !*path || !delayMsStr || !*delayMsStr) return;
+
+  const long delayMs = std::strtol(delayMsStr, nullptr, 10);
+  if (delayMs <= 0 || millis() < static_cast<unsigned long>(delayMs)) return;
+
+  if (sim_display_save_screenshot(path)) {
+    g_autoScreenshotDone = true;
+    printf("[SIM] Screenshot saved to %s\n", path);
+  }
+}
+
+void maybeAutoExit() {
+  if (g_autoExitDone) return;
+  const char* exitAfterMsStr = std::getenv("SIM_EXIT_AFTER_MS");
+  if (!exitAfterMsStr || !*exitAfterMsStr) return;
+
+  const long exitAfterMs = std::strtol(exitAfterMsStr, nullptr, 10);
+  if (exitAfterMs <= 0 || millis() < static_cast<unsigned long>(exitAfterMs)) return;
+
+  g_autoExitDone = true;
+  printf("[SIM] Auto exit after %ld ms\n", exitAfterMs);
+  std::exit(0);
 }
 }  // namespace
 
 int main(int argc, char** argv) {
-  (void)argc;
-  (void)argv;
+  if (!parseArgs(argc, argv, g_cliOptions)) {
+    printHelp();
+    return 2;
+  }
+  normalizeCliPaths(g_cliOptions);
+  if (g_cliOptions.resetSession) {
+    resetEmulatorSessionState();
+  }
+  applyCliOptions(g_cliOptions);
 
   // Ensure ./sdcard is findable: if run from build/, chdir to project root
-  if (access("./sdcard", F_OK) != 0 && access("../sdcard", F_OK) == 0) {
-    if (chdir("..") != 0) {
+  namespace fs = std::filesystem;
+  std::error_code ec;
+  if (!fs::exists("./sdcard", ec) && fs::exists("../sdcard", ec)) {
+    fs::current_path("..", ec);
+    if (ec) {
       fprintf(stderr, "Could not chdir to project root (../sdcard)\n");
     }
   }
@@ -106,16 +1386,37 @@ int main(int argc, char** argv) {
 
   printf("Crosspoint emulator: running setup() then loop(). Close window to exit.\n");
   setup();
+  maybeWriteStateJson(true);
+  if (g_cliOptions.controlStdio) {
+    startControlReader();
+  }
 
   // Single main thread: one prewarm step per frame, then events and loop (matches device).
   while (true) {
     prewarmStep();
+    maybeAutoScreenshot();
+    maybeAutoExit();
+    maybeFailWaitTimeout();
     if (!sim_display_pump_events()) {
       break;
     }
+    if (g_cliOptions.controlStdio) {
+      maybeEmitControlReady();
+    }
+    if (g_cliOptions.controlStdio) {
+      drainControlCommands();
+    }
     loop();
+    maybeSatisfyWaitCondition();
+    maybeWriteStateJson();
+    if (g_cliOptions.controlStdio) {
+      maybeEmitControlReady();
+      updateControlAction();
+      updateControlWait();
+    }
   }
 
+  maybeWriteStateJson(true);
   sim_display_shutdown();
   return 0;
 }

--- a/sim/src/obfuscation_utils_stub.cpp
+++ b/sim/src/obfuscation_utils_stub.cpp
@@ -1,0 +1,18 @@
+#include "ObfuscationUtils.h"
+
+namespace obfuscation {
+
+void xorTransform(std::string&) {}
+
+void xorTransform(std::string&, const uint8_t*, size_t) {}
+
+String obfuscateToBase64(const std::string& plaintext) { return plaintext.c_str(); }
+
+std::string deobfuscateFromBase64(const char* encoded, bool* ok) {
+  if (ok) *ok = encoded != nullptr;
+  return encoded ? std::string(encoded) : std::string();
+}
+
+void selfTest() {}
+
+}  // namespace obfuscation

--- a/sim/src/sim_display.cpp
+++ b/sim/src/sim_display.cpp
@@ -5,6 +5,7 @@
 #include <SDL.h>
 #include <cstdlib>
 #include <cstring>
+#include <string>
 
 // Rotated 90° clockwise: logical 800×480 → window 480×800
 static const int WINDOW_WIDTH = static_cast<int>(EInkDisplay::DISPLAY_HEIGHT);   // 480
@@ -143,6 +144,26 @@ bool sim_display_init(void) {
   return true;
 }
 
+bool sim_display_save_screenshot(const char* path) {
+  if (!g_renderer || !g_window || !path || !*path) return false;
+
+  int width = 0;
+  int height = 0;
+  SDL_GetRendererOutputSize(g_renderer, &width, &height);
+  if (width <= 0 || height <= 0) return false;
+
+  SDL_Surface* surface = SDL_CreateRGBSurfaceWithFormat(0, width, height, 32, SDL_PIXELFORMAT_ARGB8888);
+  if (!surface) return false;
+
+  const int readResult = SDL_RenderReadPixels(g_renderer, nullptr, SDL_PIXELFORMAT_ARGB8888, surface->pixels, surface->pitch);
+  bool ok = false;
+  if (readResult == 0) {
+    ok = SDL_SaveBMP(surface, path) == 0;
+  }
+  SDL_FreeSurface(surface);
+  return ok;
+}
+
 void sim_display_shutdown(void) {
   if (g_texture) {
     SDL_DestroyTexture(g_texture);
@@ -264,6 +285,10 @@ void HalDisplay::drawImage(const uint8_t* d, uint16_t x, uint16_t y, uint16_t w,
                            bool pm) const {
   einkDisplay.drawImage(d, x, y, w, h, pm);
 }
+void HalDisplay::drawImageTransparent(const uint8_t* d, uint16_t x, uint16_t y, uint16_t w, uint16_t h,
+                                      bool pm) const {
+  einkDisplay.drawImage(d, x, y, w, h, pm);
+}
 void HalDisplay::displayBuffer(RefreshMode mode, bool fadingFix) {
   einkDisplay.displayBuffer(static_cast<EInkDisplay::RefreshMode>(mode), fadingFix);
 }
@@ -286,9 +311,16 @@ void HalDisplay::cleanupGrayscaleBuffers(const uint8_t* b) {
 }
 void HalDisplay::displayGrayBuffer(bool fadingFix) { einkDisplay.displayGrayBuffer(fadingFix); }
 
+HalDisplay display;
+
 bool sim_display_pump_events(void) {
   SDL_Event e;
   while (SDL_PollEvent(&e)) {
+    if (e.type == SDL_KEYDOWN && e.key.keysym.sym == SDLK_F12) {
+      const char* envPath = std::getenv("SIM_SCREENSHOT_PATH");
+      const char* screenshotPath = (envPath && *envPath) ? envPath : "sim-screenshot.bmp";
+      sim_display_save_screenshot(screenshotPath);
+    }
     if (e.type == SDL_QUIT) return false;
   }
   return true;

--- a/sim/src/sim_gpio.cpp
+++ b/sim/src/sim_gpio.cpp
@@ -1,8 +1,339 @@
 #include "HalGPIO.h"
 #include "ArduinoStub.h"
+#include "sim_gpio_control.h"
+#include <activities/Activity.h>
+#include <activities/ActivityManager.h>
 
 #include <SDL.h>
+#include <algorithm>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
 #include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <mutex>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+struct ScriptStep {
+  enum class Type { ButtonPress, WaitActivity, WaitFile, WaitGlob };
+  Type type = Type::ButtonPress;
+  unsigned long atMs = 0;
+  unsigned long releaseMs = 0;
+  uint8_t button = 0xFF;
+  std::string target;
+  unsigned long timeoutMs = 0;
+  bool pressed = false;
+  bool logged = false;
+  bool started = false;
+  bool completed = false;
+};
+
+bool g_scriptLoaded = false;
+uint8_t g_scriptState = 0;
+std::vector<ScriptStep> g_scriptSteps;
+size_t g_nextScriptStep = 0;
+unsigned long g_scriptCursorMs = 0;
+uint8_t g_controlState = 0;
+std::mutex g_controlMutex;
+std::vector<ScriptStep> g_controlTapSteps;
+
+std::string trim(const std::string& value) {
+  const auto first = value.find_first_not_of(" \t\r\n");
+  if (first == std::string::npos) return "";
+  const auto last = value.find_last_not_of(" \t\r\n");
+  return value.substr(first, last - first + 1);
+}
+
+std::string upper(std::string value) {
+  std::transform(value.begin(), value.end(), value.begin(),
+                 [](unsigned char ch) { return static_cast<char>(std::toupper(ch)); });
+  return value;
+}
+
+uint8_t parseButtonName(const std::string& rawName) {
+  const std::string name = upper(trim(rawName));
+  if (name == "LEFT") return HalGPIO::BTN_LEFT;
+  if (name == "RIGHT") return HalGPIO::BTN_RIGHT;
+  if (name == "UP") return HalGPIO::BTN_UP;
+  if (name == "DOWN") return HalGPIO::BTN_DOWN;
+  if (name == "ENTER" || name == "CONFIRM") return HalGPIO::BTN_CONFIRM;
+  if (name == "BACK" || name == "ESC") return HalGPIO::BTN_BACK;
+  if (name == "POWER" || name == "P") return HalGPIO::BTN_POWER;
+  return 0xFF;
+}
+
+const char* buttonName(uint8_t button) {
+  switch (button) {
+    case HalGPIO::BTN_LEFT: return "LEFT";
+    case HalGPIO::BTN_RIGHT: return "RIGHT";
+    case HalGPIO::BTN_UP: return "UP";
+    case HalGPIO::BTN_DOWN: return "DOWN";
+    case HalGPIO::BTN_CONFIRM: return "CONFIRM";
+    case HalGPIO::BTN_BACK: return "BACK";
+    case HalGPIO::BTN_POWER: return "POWER";
+    default: return "UNKNOWN";
+  }
+}
+
+void updateControlTapState(unsigned long nowMs) {
+  std::lock_guard<std::mutex> lock(g_controlMutex);
+  for (auto& step : g_controlTapSteps) {
+    if (!step.pressed && nowMs >= step.atMs) {
+      step.pressed = true;
+      g_controlState = static_cast<uint8_t>(g_controlState | (1 << step.button));
+      std::printf("[%lu] [SIM] Control press %s\n", nowMs, buttonName(step.button));
+    }
+    if (!step.logged && nowMs >= step.releaseMs) {
+      step.logged = true;
+      g_controlState = static_cast<uint8_t>(g_controlState & ~(1 << step.button));
+      std::printf("[%lu] [SIM] Control release %s\n", nowMs, buttonName(step.button));
+    }
+  }
+  g_controlTapSteps.erase(std::remove_if(g_controlTapSteps.begin(), g_controlTapSteps.end(),
+                                         [](const ScriptStep& step) { return step.logged; }),
+                          g_controlTapSteps.end());
+}
+
+std::filesystem::path resolveSdcardPath(const std::string& path) {
+  std::string relative = path;
+  while (!relative.empty() && (relative[0] == '/' || relative[0] == '\\')) {
+    relative.erase(relative.begin());
+  }
+  return std::filesystem::path("sdcard") / std::filesystem::path(relative);
+}
+
+bool matchesSimpleGlob(const std::string& value, const std::string& pattern) {
+  const size_t star = pattern.find('*');
+  if (star == std::string::npos) return value == pattern;
+  const std::string prefix = pattern.substr(0, star);
+  const std::string suffix = pattern.substr(star + 1);
+  if (value.size() < prefix.size() + suffix.size()) return false;
+  return value.rfind(prefix, 0) == 0 && value.substr(value.size() - suffix.size()) == suffix;
+}
+
+bool globExistsUnderSdcard(const std::string& pattern) {
+  namespace fs = std::filesystem;
+  const fs::path root("sdcard");
+  std::error_code ec;
+  if (!fs::exists(root, ec)) return false;
+  for (fs::recursive_directory_iterator it(root, ec), end; it != end && !ec; it.increment(ec)) {
+    if (!it->is_regular_file(ec)) continue;
+    const std::string relative = it->path().lexically_relative(root).generic_string();
+    if (matchesSimpleGlob(relative, pattern)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void loadInputScript() {
+  if (g_scriptLoaded) return;
+  g_scriptLoaded = true;
+
+  const char* scriptPath = std::getenv("SIM_INPUT_SCRIPT");
+  if (!scriptPath || !*scriptPath) return;
+
+  std::ifstream in(scriptPath);
+  if (!in) {
+    std::fprintf(stderr, "[SIM] Failed to open input script: %s\n", scriptPath);
+    return;
+  }
+
+  std::string line;
+  int lineNo = 0;
+  while (std::getline(in, line)) {
+    ++lineNo;
+    const std::string text = trim(line);
+    if (text.empty() || text[0] == '#') continue;
+
+    std::istringstream iss(text);
+    std::string firstToken;
+    if (!(iss >> firstToken)) {
+      continue;
+    }
+
+    const std::string firstUpper = upper(firstToken);
+    if (firstUpper == "WAIT_ACTIVITY") {
+      std::string activityName;
+      unsigned long timeoutMs = 30000;
+      if (!(iss >> activityName)) {
+        std::fprintf(stderr, "[SIM] WAIT_ACTIVITY missing activity name at line %d\n", lineNo);
+        continue;
+      }
+      if (iss >> timeoutMs) {
+      }
+      ScriptStep step;
+      step.type = ScriptStep::Type::WaitActivity;
+      step.target = activityName;
+      step.timeoutMs = timeoutMs;
+      g_scriptSteps.push_back(std::move(step));
+      continue;
+    }
+
+    if (firstUpper == "WAIT_FILE") {
+      std::string filePath;
+      unsigned long timeoutMs = 30000;
+      if (!(iss >> filePath)) {
+        std::fprintf(stderr, "[SIM] WAIT_FILE missing path at line %d\n", lineNo);
+        continue;
+      }
+      if (iss >> timeoutMs) {
+      }
+      ScriptStep step;
+      step.type = ScriptStep::Type::WaitFile;
+      step.target = filePath;
+      step.timeoutMs = timeoutMs;
+      g_scriptSteps.push_back(std::move(step));
+      continue;
+    }
+
+    if (firstUpper == "WAIT_GLOB") {
+      std::string globPattern;
+      unsigned long timeoutMs = 30000;
+      if (!(iss >> globPattern)) {
+        std::fprintf(stderr, "[SIM] WAIT_GLOB missing pattern at line %d\n", lineNo);
+        continue;
+      }
+      if (iss >> timeoutMs) {
+      }
+      ScriptStep step;
+      step.type = ScriptStep::Type::WaitGlob;
+      step.target = globPattern;
+      step.timeoutMs = timeoutMs;
+      g_scriptSteps.push_back(std::move(step));
+      continue;
+    }
+
+    unsigned long atMs = 0;
+    try {
+      atMs = static_cast<unsigned long>(std::stoul(firstToken));
+    } catch (...) {
+      std::fprintf(stderr, "[SIM] Invalid script time at line %d: %s\n", lineNo, text.c_str());
+      continue;
+    }
+
+    std::string key;
+    unsigned long durationMs = 150;
+    if (!(iss >> key)) {
+      std::fprintf(stderr, "[SIM] Missing button name at line %d: %s\n", lineNo, text.c_str());
+      continue;
+    }
+    if (iss >> durationMs) {
+    }
+
+    const uint8_t button = parseButtonName(key);
+    if (button == 0xFF) {
+      std::fprintf(stderr, "[SIM] Unknown button '%s' at line %d\n", key.c_str(), lineNo);
+      continue;
+    }
+
+    ScriptStep step;
+    step.type = ScriptStep::Type::ButtonPress;
+    step.atMs = atMs;
+    step.releaseMs = atMs + durationMs;
+    step.button = button;
+    g_scriptSteps.push_back(step);
+  }
+
+  std::printf("[SIM] Loaded %zu scripted input steps from %s\n", g_scriptSteps.size(), scriptPath);
+}
+
+uint8_t scriptedButtonState() {
+  loadInputScript();
+  const unsigned long nowMs = millis();
+  updateControlTapState(nowMs);
+  if (g_scriptSteps.empty()) {
+    std::lock_guard<std::mutex> lock(g_controlMutex);
+    return g_controlState;
+  }
+  while (g_nextScriptStep < g_scriptSteps.size()) {
+    auto& step = g_scriptSteps[g_nextScriptStep];
+    if (step.type == ScriptStep::Type::WaitActivity) {
+      if (!step.started) {
+        step.started = true;
+        step.atMs = nowMs;
+        std::printf("[%lu] [SIM] Script wait activity %s\n", nowMs, step.target.c_str());
+      }
+      if (activityManager.getCurrentActivityName() == step.target) {
+        step.completed = true;
+        g_scriptCursorMs = nowMs;
+        std::printf("[%lu] [SIM] Script wait satisfied activity %s\n", nowMs, step.target.c_str());
+        g_nextScriptStep++;
+        continue;
+      }
+      if (step.timeoutMs > 0 && nowMs > step.atMs + step.timeoutMs) {
+        std::fprintf(stderr, "[SIM] Script wait timed out for activity %s\n", step.target.c_str());
+        std::exit(3);
+      }
+      break;
+    }
+
+    if (step.type == ScriptStep::Type::WaitFile) {
+      if (!step.started) {
+        step.started = true;
+        step.atMs = nowMs;
+        std::printf("[%lu] [SIM] Script wait file %s\n", nowMs, step.target.c_str());
+      }
+      if (std::filesystem::exists(resolveSdcardPath(step.target))) {
+        step.completed = true;
+        g_scriptCursorMs = nowMs;
+        std::printf("[%lu] [SIM] Script wait satisfied file %s\n", nowMs, step.target.c_str());
+        g_nextScriptStep++;
+        continue;
+      }
+      if (step.timeoutMs > 0 && nowMs > step.atMs + step.timeoutMs) {
+        std::fprintf(stderr, "[SIM] Script wait timed out for file %s\n", step.target.c_str());
+        std::exit(3);
+      }
+      break;
+    }
+
+    if (step.type == ScriptStep::Type::WaitGlob) {
+      if (!step.started) {
+        step.started = true;
+        step.atMs = nowMs;
+        std::printf("[%lu] [SIM] Script wait glob %s\n", nowMs, step.target.c_str());
+      }
+      if (globExistsUnderSdcard(step.target)) {
+        step.completed = true;
+        g_scriptCursorMs = nowMs;
+        std::printf("[%lu] [SIM] Script wait satisfied glob %s\n", nowMs, step.target.c_str());
+        g_nextScriptStep++;
+        continue;
+      }
+      if (step.timeoutMs > 0 && nowMs > step.atMs + step.timeoutMs) {
+        std::fprintf(stderr, "[SIM] Script wait timed out for glob %s\n", step.target.c_str());
+        std::exit(3);
+      }
+      break;
+    }
+
+    const uint8_t bit = static_cast<uint8_t>(1 << step.button);
+    const unsigned long startAt = g_scriptCursorMs + step.atMs;
+    const unsigned long releaseAt = g_scriptCursorMs + step.releaseMs;
+    if (!step.pressed && nowMs >= startAt) {
+      step.pressed = true;
+      g_scriptState |= bit;
+      std::printf("[%lu] [SIM] Script press %s\n", nowMs, buttonName(step.button));
+    }
+    if (step.pressed && !step.logged && nowMs >= releaseAt) {
+      step.logged = true;
+      step.completed = true;
+      g_scriptState = static_cast<uint8_t>(g_scriptState & ~bit);
+      std::printf("[%lu] [SIM] Script release %s\n", nowMs, buttonName(step.button));
+      g_nextScriptStep++;
+      continue;
+    }
+    break;
+  }
+  std::lock_guard<std::mutex> lock(g_controlMutex);
+  return static_cast<uint8_t>(g_scriptState | g_controlState);
+}
+}  // namespace
 
 static uint8_t s_keyToButton(SDL_Keycode key) {
   switch (key) {
@@ -40,6 +371,7 @@ void HalGPIO::update() {
   if (keys[SDL_SCANCODE_RETURN]) state |= (1 << BTN_CONFIRM);
   if (keys[SDL_SCANCODE_BACKSPACE] || keys[SDL_SCANCODE_ESCAPE]) state |= (1 << BTN_BACK);
   if (keys[SDL_SCANCODE_P]) state |= (1 << BTN_POWER);
+  state |= scriptedButtonState();
 
   lastState_ = state;
   for (int i = 0; i <= 6; i++) {
@@ -47,10 +379,15 @@ void HalGPIO::update() {
     if ((state & bit) && !(prevState_ & bit)) anyPressed_ = true;
     if (!(state & bit) && (prevState_ & bit)) anyReleased_ = true;
   }
-  if (state & ((1 << BTN_CONFIRM) | (1 << BTN_POWER)))
-    pressStartMs_ = pressStartMs_ ? pressStartMs_ : millis();
-  else
+  if (state != 0) {
+    if (prevState_ == 0) {
+      pressStartMs_ = millis();
+    } else if (!pressStartMs_) {
+      pressStartMs_ = millis();
+    }
+  } else {
     pressStartMs_ = 0;
+  }
 }
 
 bool HalGPIO::isPressed(uint8_t buttonIndex) const {
@@ -88,4 +425,45 @@ void sim_gpio_pump_events() {
   while (SDL_PollEvent(&e)) {
     if (e.type == SDL_QUIT) std::exit(0);
   }
+}
+
+bool sim_gpio_try_parse_button(const std::string& name, uint8_t& outButton) {
+  outButton = parseButtonName(name);
+  return outButton != 0xFF;
+}
+
+const char* sim_gpio_button_name(uint8_t button) { return buttonName(button); }
+
+void sim_gpio_press_button(uint8_t button) {
+  std::lock_guard<std::mutex> lock(g_controlMutex);
+  g_controlState = static_cast<uint8_t>(g_controlState | (1 << button));
+}
+
+void sim_gpio_release_button(uint8_t button) {
+  std::lock_guard<std::mutex> lock(g_controlMutex);
+  g_controlState = static_cast<uint8_t>(g_controlState & ~(1 << button));
+  g_controlTapSteps.erase(std::remove_if(g_controlTapSteps.begin(), g_controlTapSteps.end(),
+                                         [button](const ScriptStep& step) { return step.button == button; }),
+                          g_controlTapSteps.end());
+}
+
+void sim_gpio_release_all_buttons() {
+  std::lock_guard<std::mutex> lock(g_controlMutex);
+  g_controlState = 0;
+  g_controlTapSteps.clear();
+}
+
+void sim_gpio_tap_button(uint8_t button, unsigned long durationMs) {
+  sim_gpio_queue_tap_button(button, durationMs, 0);
+}
+
+void sim_gpio_queue_tap_button(uint8_t button, unsigned long durationMs, unsigned long delayMs) {
+  std::lock_guard<std::mutex> lock(g_controlMutex);
+  const unsigned long nowMs = millis();
+  ScriptStep step;
+  step.type = ScriptStep::Type::ButtonPress;
+  step.button = button;
+  step.atMs = nowMs + delayMs;
+  step.releaseMs = step.atMs + durationMs;
+  g_controlTapSteps.push_back(step);
 }

--- a/sim/src/sim_storage.cpp
+++ b/sim/src/sim_storage.cpp
@@ -6,12 +6,34 @@
 
 #include <algorithm>
 #include <cerrno>
-#include <climits>
 #include <cstring>
-#include <dirent.h>
+#include <direct.h>
+#include <filesystem>
 #include <stdlib.h>
 #include <sys/stat.h>
-#include <unistd.h>
+
+namespace fs = std::filesystem;
+
+namespace {
+#ifndef S_ISDIR
+#define S_ISDIR(mode) (((mode) & _S_IFMT) == _S_IFDIR)
+#endif
+
+struct SimDirHandle {
+  fs::directory_iterator current;
+  fs::directory_iterator end;
+
+  explicit SimDirHandle(const std::string& path) : current(fs::path(path)), end() {}
+};
+
+bool createParentDirectories(const std::string& fullPath) {
+  std::error_code ec;
+  const fs::path parent = fs::path(fullPath).parent_path();
+  if (parent.empty()) return true;
+  fs::create_directories(parent, ec);
+  return !ec;
+}
+}  // namespace
 
 std::string FsFile::s_rootPath = "./sdcard";
 
@@ -53,7 +75,7 @@ void FsFile::close() {
     fp_ = nullptr;
   }
   if (dir_) {
-    closedir(static_cast<DIR*>(dir_));
+    delete static_cast<SimDirHandle*>(dir_);
     dir_ = nullptr;
   }
   isDir_ = false;
@@ -66,24 +88,19 @@ bool FsFile::openFullPath(const char* fullPath, oflag_t oflag) {
   SpiBusGuard guard;
   close();
   if (!fullPath) return false;
+  std::error_code ec;
+  const fs::path path(fullPath);
   struct stat st;
   if (stat(fullPath, &st) != 0) {
     if ((oflag & O_CREAT) && (oflag & (O_WRONLY | O_RDWR))) {
-      std::string p(fullPath);
-      for (size_t i = 1; i < p.size(); i++) {
-        if (p[i] == '/') {
-          std::string part = p.substr(0, i);
-          if (mkdir(part.c_str(), 0755) != 0 && errno != EEXIST) return false;
-        }
-      }
+      if (!createParentDirectories(fullPath)) return false;
     }
     fp_ = fopen(fullPath, (oflag & O_RDWR) ? "wb+" : "wb");
     if (fp_) filePath_ = fullPath;
     return fp_ != nullptr;
   }
   if (S_ISDIR(st.st_mode)) {
-    DIR* d = opendir(fullPath);
-    if (!d) return false;
+    auto* d = new SimDirHandle(fullPath);
     dir_ = d;
     isDir_ = true;
     dirPath_ = fullPath;
@@ -168,7 +185,9 @@ int FsFile::available() {
 }
 
 void FsFile::rewindDirectory() {
-  if (dir_) rewinddir(static_cast<DIR*>(dir_));
+  if (!dir_ || dirPath_.empty()) return;
+  delete static_cast<SimDirHandle*>(dir_);
+  dir_ = new SimDirHandle(dirPath_);
 }
 
 bool FsFile::getName(char* name, size_t size) const {
@@ -194,14 +213,19 @@ size_t FsFile::size() const {
 
 FsFile FsFile::openNextFile() {
   if (!dir_) return FsFile();
-  struct dirent* ent = readdir(static_cast<DIR*>(dir_));
-  while (ent && (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0))
-    ent = readdir(static_cast<DIR*>(dir_));
-  if (!ent) return FsFile();
-  std::string fullPath = dirPath_ + "/" + ent->d_name;
+  auto* handle = static_cast<SimDirHandle*>(dir_);
+  while (handle->current != handle->end) {
+    const fs::directory_entry entry = *handle->current;
+    ++handle->current;
+    const std::string fileName = entry.path().filename().string();
+    if (fileName == "." || fileName == "..") continue;
+    const std::string fullPath = entry.path().string();
+    FsFile next;
+    if (!next.openFullPath(fullPath.c_str(), O_RDONLY)) continue;
+    next.setCurrentName(fileName);
+    return next;
+  }
   FsFile next;
-  if (!next.openFullPath(fullPath.c_str(), O_RDONLY)) return FsFile();
-  next.setCurrentName(ent->d_name);
   return next;
 }
 
@@ -226,21 +250,12 @@ FsFile SdFat::open(const char* path, oflag_t oflag) {
 bool SdFat::mkdir(const char* path, bool pFlag) {
   std::string full = FsFile::resolvePath(path);
   if (full.empty()) return false;
+  std::error_code ec;
   if (pFlag) {
-    // Create parent directories incrementally.
-    // Example: /a/b/c -> mkdir(/a), mkdir(/a/b), mkdir(/a/b/c)
-    const size_t start = (full[0] == '/') ? 1 : 0;
-    for (size_t i = start; i <= full.size(); ++i) {
-      if (i == full.size() || full[i] == '/') {
-        if (i == 0) continue;
-        const std::string part = full.substr(0, i);
-        if (part.empty()) continue;
-        if (::mkdir(part.c_str(), 0755) != 0 && errno != EEXIST) return false;
-      }
-    }
-    return true;
+    fs::create_directories(fs::path(full), ec);
+    return !ec || ec.value() == 0;
   }
-  return ::mkdir(full.c_str(), 0755) == 0 || errno == EEXIST;
+  return fs::create_directory(fs::path(full), ec) || fs::exists(fs::path(full), ec);
 }
 
 bool SdFat::exists(const char* path) {
@@ -254,7 +269,8 @@ bool SdFat::remove(const char* path) {
 }
 
 bool SdFat::rmdir(const char* path) {
-  return ::rmdir(FsFile::resolvePath(path).c_str()) == 0;
+  std::error_code ec;
+  return fs::remove(fs::path(FsFile::resolvePath(path)), ec) && !ec;
 }
 
 SDCardManager SDCardManager::instance;
@@ -263,16 +279,23 @@ SDCardManager::SDCardManager() = default;
 
 bool SDCardManager::begin() {
   // Use absolute path so directory listing works regardless of process cwd (e.g. when run from build/)
-  char resolved[PATH_MAX];
-  if (realpath("./sdcard", resolved) != nullptr) {
-    FsFile::setRootPath(resolved);
-    Serial.printf("[%lu] [SD] Sim SD card %s\n", millis(), resolved);
-  } else if (realpath("../sdcard", resolved) != nullptr) {
-    FsFile::setRootPath(resolved);
-    Serial.printf("[%lu] [SD] Sim SD card %s (from ../sdcard)\n", millis(), resolved);
+  std::error_code ec;
+  fs::path resolved = fs::absolute("./sdcard", ec);
+  if (!ec && fs::exists(resolved, ec)) {
+    const std::string resolvedStr = resolved.lexically_normal().string();
+    FsFile::setRootPath(resolvedStr);
+    Serial.printf("[%lu] [SD] Sim SD card %s\n", millis(), resolvedStr.c_str());
   } else {
-    FsFile::setRootPath("./sdcard");
-    Serial.printf("[%lu] [SD] Sim SD card (./sdcard, realpath failed)\n", millis());
+    ec.clear();
+    resolved = fs::absolute("../sdcard", ec);
+    if (!ec && fs::exists(resolved, ec)) {
+      const std::string resolvedStr = resolved.lexically_normal().string();
+      FsFile::setRootPath(resolvedStr);
+      Serial.printf("[%lu] [SD] Sim SD card %s (from ../sdcard)\n", millis(), resolvedStr.c_str());
+    } else {
+      FsFile::setRootPath("./sdcard");
+      Serial.printf("[%lu] [SD] Sim SD card (./sdcard, realpath failed)\n", millis());
+    }
   }
   initialized = true;
   return initialized;

--- a/sim/src/uzlib_checksums_stub.cpp
+++ b/sim/src/uzlib_checksums_stub.cpp
@@ -1,0 +1,31 @@
+#include <cstddef>
+#include <cstdint>
+
+extern "C" {
+
+uint32_t uzlib_adler32(const void* data, unsigned int length, uint32_t prev_sum) {
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  uint32_t a = prev_sum & 0xFFFFu;
+  uint32_t b = (prev_sum >> 16) & 0xFFFFu;
+  if (a == 0) a = 1;
+  for (unsigned int i = 0; i < length; ++i) {
+    a = (a + bytes[i]) % 65521u;
+    b = (b + a) % 65521u;
+  }
+  return (b << 16) | a;
+}
+
+uint32_t uzlib_crc32(const void* data, unsigned int length, uint32_t crc) {
+  const auto* bytes = static_cast<const uint8_t*>(data);
+  crc = ~crc;
+  for (unsigned int i = 0; i < length; ++i) {
+    crc ^= bytes[i];
+    for (int bit = 0; bit < 8; ++bit) {
+      const uint32_t mask = static_cast<uint32_t>(-(static_cast<int32_t>(crc & 1u)));
+      crc = (crc >> 1) ^ (0xEDB88320u & mask);
+    }
+  }
+  return ~crc;
+}
+
+}  // extern "C"

--- a/sim/src/webdav_handler_stub.cpp
+++ b/sim/src/webdav_handler_stub.cpp
@@ -1,0 +1,9 @@
+#include "network/WebDAVHandler.h"
+
+bool WebDAVHandler::canHandle(WebServer&, HTTPMethod, const String&) { return false; }
+
+bool WebDAVHandler::canRaw(WebServer&, const String&) { return false; }
+
+void WebDAVHandler::raw(WebServer&, const String&, HTTPRaw&) {}
+
+bool WebDAVHandler::handle(WebServer&, HTTPMethod, const String&) { return false; }


### PR DESCRIPTION
## Summary

This PR improves the native emulator in two areas:

1. make the emulator build more reliably on Windows
2. add a generic machine-readable stdin/stdout control channel for automation

## What changed

### Windows build/runtime compatibility
- raise the emulator toolchain target to C++20
- improve `CROSSPOINT_ROOT` auto-detection for common sibling layouts
- detect Python more robustly on Windows for the HTML header generation step
- include additional Crosspoint libraries and stubs required by newer firmware code
- add missing compatibility shims for Windows/MSVC builds
- link `winhttp` where needed
- copy `SDL2.dll` after build when `SDL2_ROOT` is provided
- ignore local build/test temp artifacts

### Generic emulator control CLI
- add `--control-stdio`
- emit structured `[SIMCTL]` JSON events to stdout
- add state/screen inspection commands
- add barrier-style wait commands driven by UI state instead of timing-only scripts
- add semantic text input for keyboard-entry flows
- add screenshot capture support
- add state-driven helpers for menu/list activation and back navigation
- add `--reset-session` for deterministic emulator runs
- document the protocol in `docs/control-stdio.md`

## Why

This makes the emulator much easier to:
- build on Windows
- automate in a repeatable way
- integrate with higher-level test harnesses without relying on fragile sleep-based scripts

